### PR TITLE
Fix _refresh() clears _pending_refresh (#29)

### DIFF
--- a/addons/tau-plot/plot/plot.gd
+++ b/addons/tau-plot/plot/plot.gd
@@ -114,7 +114,10 @@ signal sample_clicked(hits: Array[SampleHit])
 signal sample_click_dismissed()
 
 
-var _pending_refresh := false
+# A request stands until it renders.
+var _refresh_requested := false
+# Only covers the frame being awaited.
+var _refresh_scheduled := false
 
 # Stands in for legend_config when the user leaves it unset, so the plot
 # internals always read a config. Its defaults are the documented ones.
@@ -163,8 +166,8 @@ func _notification(what: int) -> void:
 			# Entering at the size it already had raises no
 			# NOTIFICATION_RESIZED, so a request made outside the tree is run
 			# here.
-			if _pending_refresh:
-				_refresh_next_frame()
+			if _refresh_requested:
+				_schedule_refresh()
 		NOTIFICATION_RESIZED:
 			_refresh()
 		NOTIFICATION_THEME_CHANGED:
@@ -204,30 +207,25 @@ func plot_xy(p_dataset: Dataset, p_xy_config: TauXYConfig, p_series_bindings: Ar
 
 
 # TODO
-func plot_pie():
+func plot_pie() -> void:
 	push_error("PIE plots are not implemented yet")
 
 
 # TODO
-func plot_radar():
+func plot_radar() -> void:
 	push_error("RADAR plots are not implemented yet")
 
 
-func refresh_now():
+func refresh_now() -> void:
 	_refresh()
 
 
-func queue_refresh():
-	if _pending_refresh:
-		return # Already scheduled
-	_pending_refresh = true
-	# Outside the tree there is no frame to wait for and nothing to lay out.
-	# NOTIFICATION_ENTER_TREE runs the pending request.
-	if is_inside_tree():
-		_refresh_next_frame()
+func queue_refresh() -> void:
+	_refresh_requested = true
+	_schedule_refresh()
 
 
-func reset():
+func reset() -> void:
 	_reset_active_plot()
 	_plot_title.visible = false
 	queue_redraw()
@@ -238,15 +236,22 @@ func reset():
 ####################################################################################################
 
 func _refresh() -> void:
-	_pending_refresh = false
 	if _xy_plot != null:
 		_xy_plot.refresh(global_position, _effective_legend_config().position)
 
 
-# Waits one frame to let label visibility changes propagate through the layout
-# system, then runs the pending refresh.
-func _refresh_next_frame() -> void:
+# Waits one frame so the layout settles before the refresh measures it.
+# Outside the tree there is nothing to lay out, so the request waits for NOTIFICATION_ENTER_TREE.
+func _schedule_refresh() -> void:
+	if _refresh_scheduled or not is_inside_tree():
+		return
+	_refresh_scheduled = true
 	await get_tree().process_frame
+	_refresh_scheduled = false
+	if not is_inside_tree():
+		return
+	# Cleared first so an internal request made during the refresh schedules the next one.
+	_refresh_requested = false
 	_refresh()
 
 

--- a/documentation/docs/api/tau_plot.md
+++ b/documentation/docs/api/tau_plot.md
@@ -339,7 +339,7 @@ queue_refresh() -> void
 
 Schedules a render update for the next frame.
 
-If a refresh is already pending, does nothing. Call this after mutating a configuration property on the objects passed to [`plot_xy()`](#plot_xy) to apply the change.
+Call this after mutating a configuration property on the objects passed to [`plot_xy()`](#plot_xy) to apply the change. Repeated calls before the render coalesce into a single update.
 
 On a node outside the scene tree, the request is held and the render happens when the node enters the tree.
 
@@ -351,7 +351,11 @@ On a node outside the scene tree, the request is held and the render happens whe
 refresh_now() -> void
 ```
 
-Forces an immediate refresh in the current frame. Use this only when the plot needs to be up to date synchronously. For most UI-driven updates, prefer [`queue_refresh()`](#queue_refresh), since theme and layout changes may settle on the next frame.
+Renders in the current frame instead of the next one.
+
+For a visual-only change this gives the same result as [`queue_refresh()`](#queue_refresh), one frame earlier. A change that affects the layout may still need the next frame to settle. Prefer [`queue_refresh()`](#queue_refresh) unless a per-frame animation cannot afford the extra frame.
+
+A render already scheduled by [`queue_refresh()`](#queue_refresh) is not cancelled and still runs on the next frame.
 
 ## Related Classes
 

--- a/documentation/docs/runtime-configuration-change-limitations.md
+++ b/documentation/docs/runtime-configuration-change-limitations.md
@@ -1,6 +1,8 @@
 # Runtime Configuration Change Limitations
 
-The plot keeps a reference to the configuration objects you pass to [`plot_xy()`](api/tau_plot.md#plot_xy). To change a property on one of them while the plot is displayed, assign the property, then call [`TauPlot.queue_refresh()`](api/tau_plot.md#queue_refresh) or [`TauPlot.refresh_now()`](api/tau_plot.md#refresh_now).
+The plot keeps a reference to the configuration objects you pass to [`plot_xy()`](api/tau_plot.md#plot_xy). To change a property on one of them while the plot is displayed, assign the property, then call [`TauPlot.queue_refresh()`](api/tau_plot.md#queue_refresh).
+
+[`TauPlot.refresh_now()`](api/tau_plot.md#refresh_now) applies the change in the current frame instead of the next one, which gives the same result only for a visual-only change: a change that affects the layout may still need the next frame to settle. Prefer `queue_refresh()` unless a per-frame animation cannot afford the extra frame.
 
 Some properties do not work that way yet. The tables below list every configuration property and tell you which ones do.
 


### PR DESCRIPTION
## Description

Fix #29 

## Testing

With existing tests calling `queue_refresh` or `refresh_now`.

## AI disclosure

For documentation and review only.