### PR TITLE
Optimize renderers

### DIFF
--- a/addons/tau-plot/CHANGELOG.md
+++ b/addons/tau-plot/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `TauXYSeriesBinding.show_in_legend`. Set it to `false` to keep a series out of the legend while still drawing it. Defaults to `true`.
 - `SampleHit.contains_pointer` tells whether the cursor is inside the hit zone of the sample rather than merely nearest to it. It is what gates the highlight.
 - `DatasetChange`, the payload of `Dataset.changed`, is now public and documented.
+- **Bulk reads and fast value getters** on `Dataset` and the five ring buffer classes: `Dataset.get_series_y_slice()`, `Dataset.get_shared_x_numeric_slice()`, `Dataset.get_series_x_numeric_slice()`, and `get_values()` and `get_value_unsafe()` on `ColorBuffer`, `Float32Buffer`, `Float64Buffer`, `Int32Buffer` and `StringBuffer`.
 - `StackedNormalization`, `StackedNegativePolicy`, `DatasetChange`, `LineVisualAttributes` and `LineVisualCallbacks` are reachable through the `TauPlot` namespace.
 - Resolved styles are checked for consistency once per plot build, and report the property combinations they cannot draw as a warning or an error.
 
@@ -49,6 +50,7 @@
 - The first hit of `sample_hovered` and `sample_clicked` is now the sample closest to the cursor, instead of the first overlay that answered. The `SNAP_TO_POINT` tooltip anchor follows it.
 - The X crosshair line is drawn at the hovered X position instead of at the hovered sample.
 - The built-in tooltip prints the X value on each line when the hits do not share the same X value.
+- `Dataset` and the ring buffers behind it have been optimized internally. Reading and writing samples is faster, with no API change and no behavior change.
 
 ### Fixed
 

--- a/addons/tau-plot/model/color_buffer.gd
+++ b/addons/tau-plot/model/color_buffer.gd
@@ -44,19 +44,56 @@ class ColorBuffer extends RefCounted:
 
 
 	func get_value(p_logical_index: int) -> Color:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("ColorBuffer: the buffer is empty")
 			return NO_COLOR
 
-		return _buffer[storage_i]
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("ColorBuffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return NO_COLOR
+
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	# Unsafe: it does not check the index. Outside [0; size()[ it reads the
+	# wrong slot of the ring storage and reports no error. Only call it when
+	# the index is already known to be valid.
+	func get_value_unsafe(p_logical_index: int) -> Color:
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	func get_values(p_start_index: int, p_count: int) -> PackedColorArray:
+		if p_count <= 0:
+			return PackedColorArray()
+
+		if p_start_index < 0 or p_start_index + p_count > _stored_count:
+			push_error("ColorBuffer: range [%d; %d[ out of range [0; %d[" % [p_start_index, p_start_index + p_count, _stored_count])
+			return PackedColorArray()
+
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the read is cut at the ring seam into one or two native
+		# slices. Reading one value at a time would cost a loop step and an
+		# index mapping per value, which is most of the cost of a big read.
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := _capacity - start
+		if p_count <= head:
+			return _buffer.slice(start, start + p_count)
+
+		var out := _buffer.slice(start, _capacity)
+		out.append_array(_buffer.slice(0, p_count - head))
+		return out
 
 
 	func set_value(p_logical_index: int, p_value: Color) -> void:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("ColorBuffer: the buffer is empty")
 			return
 
-		_buffer[storage_i] = p_value
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("ColorBuffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return
+
+		_buffer[(_storage_origin() + p_logical_index) % _capacity] = p_value
 
 
 	func set_values(p_start_index: int, p_values: PackedColorArray) -> int:
@@ -71,12 +108,24 @@ class ColorBuffer extends RefCounted:
 			push_error("ColorBuffer: start_index %d out of range [0; %d[" % [p_start_index, _stored_count])
 			return 0
 
-		var max_write := min(p_values.size(), _stored_count - p_start_index)
-		for i in range(max_write):
-			var storage_i := _map_logical_to_storage(p_start_index + i)
-			_buffer[storage_i] = p_values[i]
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the write is cut at the ring seam into two contiguous runs.
+		# Mapping each index on its own would repeat the check and the origin
+		# maths for every value.
+		#
+		# The write stays in place on purpose. Rebuilding the storage from
+		# slices would be one native copy, but it would allocate the whole
+		# buffer again, which is slower for the small writes a streaming plot
+		# makes.
+		var write_count := min(p_values.size(), _stored_count - p_start_index)
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := min(write_count, _capacity - start)
+		for i in range(head):
+			_buffer[start + i] = p_values[i]
+		for i in range(write_count - head):
+			_buffer[i] = p_values[head + i]
 
-		return max_write
+		return write_count
 
 
 	func append_value(p_value: Color) -> int:
@@ -122,21 +171,12 @@ class ColorBuffer extends RefCounted:
 	# Private
 	####################################################################################################
 
-	# Negative when the logical index has no storage slot.
-	func _map_logical_to_storage(p_logical_index: int) -> int:
-		if _stored_count <= 0:
-			push_error("ColorBuffer: the buffer is empty")
-			return -1
-
-		if p_logical_index < 0 or p_logical_index >= _stored_count:
-			push_error("ColorBuffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
-			return -1
-
-		var oldest_storage := _storage_head - _stored_count
-		if oldest_storage < 0:
-			oldest_storage += _capacity
-
-		return (oldest_storage + p_logical_index) % _capacity
+	# Storage index of logical index 0. It checks nothing, so a bulk read or
+	# write can call it once before its loop and then index the storage
+	# directly. Callers check the logical range themselves.
+	func _storage_origin() -> int:
+		var origin := _storage_head - _stored_count
+		return origin + _capacity if origin < 0 else origin
 
 
 	static func _resize_ring_buffer(p_old: PackedColorArray, p_old_cap: int, p_old_head: int, p_old_count: int, p_new_cap: int) -> PackedColorArray:

--- a/addons/tau-plot/model/dataset.gd
+++ b/addons/tau-plot/model/dataset.gd
@@ -492,6 +492,15 @@ class Dataset extends RefCounted:
 		return xb.get_value(p_logical_sample_index)
 
 
+	# The result is a copy.
+	func get_shared_x_numeric_slice(p_start_index: int, p_count: int) -> PackedFloat64Array:
+		if _mode != Mode.SHARED_X or _x_element_type != XElementType.NUMERIC:
+			push_error("Dataset.get_shared_x_numeric_slice(): requires SHARED_X mode with a NUMERIC X element type")
+			return PackedFloat64Array()
+
+		return _x_buffers[0].get_values(p_start_index, p_count)
+
+
 	func set_shared_x(p_logical_sample_index: int, p_x: Variant) -> void:
 		if _mode != Mode.SHARED_X:
 			push_error("Dataset.set_shared_x(): only valid in SHARED_X mode")
@@ -531,6 +540,19 @@ class Dataset extends RefCounted:
 		return xb.get_value(p_logical_sample_index)
 
 
+	# The result is a copy.
+	func get_series_x_numeric_slice(p_series_id: int, p_start_index: int, p_count: int) -> PackedFloat64Array:
+		if _mode != Mode.PER_SERIES_X or _x_element_type != XElementType.NUMERIC:
+			push_error("Dataset.get_series_x_numeric_slice(): requires PER_SERIES_X mode with a NUMERIC X element type")
+			return PackedFloat64Array()
+
+		var idx := _require_series_exists(p_series_id)
+		if idx < 0:
+			return PackedFloat64Array()
+
+		return _x_buffers[idx].get_values(p_start_index, p_count)
+
+
 	func set_series_x(p_series_id: int, p_logical_sample_index: int, p_x: Variant) -> void:
 		if _mode != Mode.PER_SERIES_X:
 			push_error("Dataset.set_series_x(): only valid in PER_SERIES_X mode")
@@ -562,6 +584,15 @@ class Dataset extends RefCounted:
 		if idx < 0:
 			return 0.0
 		return _y_buffers[idx].get_value(p_logical_sample_index)
+
+
+	# The result is a copy.
+	func get_series_y_slice(p_series_id: int, p_start_index: int, p_count: int) -> PackedFloat64Array:
+		var idx := _require_series_exists(p_series_id)
+		if idx < 0:
+			return PackedFloat64Array()
+
+		return _y_buffers[idx].get_values(p_start_index, p_count)
 
 
 	func set_series_y(p_series_id: int, p_logical_sample_index: int, p_y: float) -> void:

--- a/addons/tau-plot/model/float32_buffer.gd
+++ b/addons/tau-plot/model/float32_buffer.gd
@@ -42,19 +42,56 @@ class Float32Buffer extends RefCounted:
 
 
 	func get_value(p_logical_index: int) -> float:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("Float32Buffer: the buffer is empty")
 			return 0.0
 
-		return _buffer[storage_i]
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("Float32Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return 0.0
+
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	# Unsafe: it does not check the index. Outside [0; size()[ it reads the
+	# wrong slot of the ring storage and reports no error. Only call it when
+	# the index is already known to be valid.
+	func get_value_unsafe(p_logical_index: int) -> float:
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	func get_values(p_start_index: int, p_count: int) -> PackedFloat32Array:
+		if p_count <= 0:
+			return PackedFloat32Array()
+
+		if p_start_index < 0 or p_start_index + p_count > _stored_count:
+			push_error("Float32Buffer: range [%d; %d[ out of range [0; %d[" % [p_start_index, p_start_index + p_count, _stored_count])
+			return PackedFloat32Array()
+
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the read is cut at the ring seam into one or two native
+		# slices. Reading one value at a time would cost a loop step and an
+		# index mapping per value, which is most of the cost of a big read.
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := _capacity - start
+		if p_count <= head:
+			return _buffer.slice(start, start + p_count)
+
+		var out := _buffer.slice(start, _capacity)
+		out.append_array(_buffer.slice(0, p_count - head))
+		return out
 
 
 	func set_value(p_logical_index: int, p_value: float) -> void:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("Float32Buffer: the buffer is empty")
 			return
 
-		_buffer[storage_i] = p_value
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("Float32Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return
+
+		_buffer[(_storage_origin() + p_logical_index) % _capacity] = p_value
 
 
 	func set_values(p_start_index: int, p_values: PackedFloat32Array) -> int:
@@ -69,12 +106,24 @@ class Float32Buffer extends RefCounted:
 			push_error("Float32Buffer: start_index %d out of range [0; %d[" % [p_start_index, _stored_count])
 			return 0
 
-		var max_write := min(p_values.size(), _stored_count - p_start_index)
-		for i in range(max_write):
-			var storage_i := _map_logical_to_storage(p_start_index + i)
-			_buffer[storage_i] = p_values[i]
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the write is cut at the ring seam into two contiguous runs.
+		# Mapping each index on its own would repeat the check and the origin
+		# maths for every value.
+		#
+		# The write stays in place on purpose. Rebuilding the storage from
+		# slices would be one native copy, but it would allocate the whole
+		# buffer again, which is slower for the small writes a streaming plot
+		# makes.
+		var write_count := min(p_values.size(), _stored_count - p_start_index)
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := min(write_count, _capacity - start)
+		for i in range(head):
+			_buffer[start + i] = p_values[i]
+		for i in range(write_count - head):
+			_buffer[i] = p_values[head + i]
 
-		return max_write
+		return write_count
 
 
 	func append_value(p_value: float) -> int:
@@ -120,21 +169,12 @@ class Float32Buffer extends RefCounted:
 	# Private
 	####################################################################################################
 
-	# Negative when the logical index has no storage slot.
-	func _map_logical_to_storage(p_logical_index: int) -> int:
-		if _stored_count <= 0:
-			push_error("Float32Buffer: the buffer is empty")
-			return -1
-
-		if p_logical_index < 0 or p_logical_index >= _stored_count:
-			push_error("Float32Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
-			return -1
-
-		var oldest_storage := _storage_head - _stored_count
-		if oldest_storage < 0:
-			oldest_storage += _capacity
-
-		return (oldest_storage + p_logical_index) % _capacity
+	# Storage index of logical index 0. It checks nothing, so a bulk read or
+	# write can call it once before its loop and then index the storage
+	# directly. Callers check the logical range themselves.
+	func _storage_origin() -> int:
+		var origin := _storage_head - _stored_count
+		return origin + _capacity if origin < 0 else origin
 
 
 	static func _resize_ring_buffer(p_old: PackedFloat32Array, p_old_cap: int, p_old_head: int, p_old_count: int, p_new_cap: int) -> PackedFloat32Array:

--- a/addons/tau-plot/model/float64_buffer.gd
+++ b/addons/tau-plot/model/float64_buffer.gd
@@ -42,19 +42,56 @@ class Float64Buffer extends RefCounted:
 
 
 	func get_value(p_logical_index: int) -> float:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("Float64Buffer: the buffer is empty")
 			return 0.0
 
-		return _buffer[storage_i]
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("Float64Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return 0.0
+
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	# Unsafe: it does not check the index. Outside [0; size()[ it reads the
+	# wrong slot of the ring storage and reports no error. Only call it when
+	# the index is already known to be valid.
+	func get_value_unsafe(p_logical_index: int) -> float:
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	func get_values(p_start_index: int, p_count: int) -> PackedFloat64Array:
+		if p_count <= 0:
+			return PackedFloat64Array()
+
+		if p_start_index < 0 or p_start_index + p_count > _stored_count:
+			push_error("Float64Buffer: range [%d; %d[ out of range [0; %d[" % [p_start_index, p_start_index + p_count, _stored_count])
+			return PackedFloat64Array()
+
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the read is cut at the ring seam into one or two native
+		# slices. Reading one value at a time would cost a loop step and an
+		# index mapping per value, which is most of the cost of a big read.
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := _capacity - start
+		if p_count <= head:
+			return _buffer.slice(start, start + p_count)
+
+		var out := _buffer.slice(start, _capacity)
+		out.append_array(_buffer.slice(0, p_count - head))
+		return out
 
 
 	func set_value(p_logical_index: int, p_value: float) -> void:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("Float64Buffer: the buffer is empty")
 			return
 
-		_buffer[storage_i] = p_value
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("Float64Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return
+
+		_buffer[(_storage_origin() + p_logical_index) % _capacity] = p_value
 
 
 	func set_values(p_start_index: int, p_values: PackedFloat64Array) -> int:
@@ -69,12 +106,24 @@ class Float64Buffer extends RefCounted:
 			push_error("Float64Buffer: start_index %d out of range [0; %d[" % [p_start_index, _stored_count])
 			return 0
 
-		var max_write := min(p_values.size(), _stored_count - p_start_index)
-		for i in range(max_write):
-			var storage_i := _map_logical_to_storage(p_start_index + i)
-			_buffer[storage_i] = p_values[i]
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the write is cut at the ring seam into two contiguous runs.
+		# Mapping each index on its own would repeat the check and the origin
+		# maths for every value.
+		#
+		# The write stays in place on purpose. Rebuilding the storage from
+		# slices would be one native copy, but it would allocate the whole
+		# buffer again, which is slower for the small writes a streaming plot
+		# makes.
+		var write_count := min(p_values.size(), _stored_count - p_start_index)
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := min(write_count, _capacity - start)
+		for i in range(head):
+			_buffer[start + i] = p_values[i]
+		for i in range(write_count - head):
+			_buffer[i] = p_values[head + i]
 
-		return max_write
+		return write_count
 
 
 	func append_value(p_value: float) -> int:
@@ -120,21 +169,12 @@ class Float64Buffer extends RefCounted:
 	# Private
 	####################################################################################################
 
-	# Negative when the logical index has no storage slot.
-	func _map_logical_to_storage(p_logical_index: int) -> int:
-		if _stored_count <= 0:
-			push_error("Float64Buffer: the buffer is empty")
-			return -1
-
-		if p_logical_index < 0 or p_logical_index >= _stored_count:
-			push_error("Float64Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
-			return -1
-
-		var oldest_storage := _storage_head - _stored_count
-		if oldest_storage < 0:
-			oldest_storage += _capacity
-
-		return (oldest_storage + p_logical_index) % _capacity
+	# Storage index of logical index 0. It checks nothing, so a bulk read or
+	# write can call it once before its loop and then index the storage
+	# directly. Callers check the logical range themselves.
+	func _storage_origin() -> int:
+		var origin := _storage_head - _stored_count
+		return origin + _capacity if origin < 0 else origin
 
 
 	static func _resize_ring_buffer(p_old: PackedFloat64Array, p_old_cap: int, p_old_head: int, p_old_count: int, p_new_cap: int) -> PackedFloat64Array:

--- a/addons/tau-plot/model/int32_buffer.gd
+++ b/addons/tau-plot/model/int32_buffer.gd
@@ -43,19 +43,56 @@ class Int32Buffer extends RefCounted:
 
 
 	func get_value(p_logical_index: int) -> int:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("Int32Buffer: the buffer is empty")
 			return -1
 
-		return _buffer[storage_i]
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("Int32Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return -1
+
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	# Unsafe: it does not check the index. Outside [0; size()[ it reads the
+	# wrong slot of the ring storage and reports no error. Only call it when
+	# the index is already known to be valid.
+	func get_value_unsafe(p_logical_index: int) -> int:
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	func get_values(p_start_index: int, p_count: int) -> PackedInt32Array:
+		if p_count <= 0:
+			return PackedInt32Array()
+
+		if p_start_index < 0 or p_start_index + p_count > _stored_count:
+			push_error("Int32Buffer: range [%d; %d[ out of range [0; %d[" % [p_start_index, p_start_index + p_count, _stored_count])
+			return PackedInt32Array()
+
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the read is cut at the ring seam into one or two native
+		# slices. Reading one value at a time would cost a loop step and an
+		# index mapping per value, which is most of the cost of a big read.
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := _capacity - start
+		if p_count <= head:
+			return _buffer.slice(start, start + p_count)
+
+		var out := _buffer.slice(start, _capacity)
+		out.append_array(_buffer.slice(0, p_count - head))
+		return out
 
 
 	func set_value(p_logical_index: int, p_value: int) -> void:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("Int32Buffer: the buffer is empty")
 			return
 
-		_buffer[storage_i] = p_value
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("Int32Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return
+
+		_buffer[(_storage_origin() + p_logical_index) % _capacity] = p_value
 
 
 	func set_values(p_start_index: int, p_values: PackedInt32Array) -> int:
@@ -70,12 +107,24 @@ class Int32Buffer extends RefCounted:
 			push_error("Int32Buffer: start_index %d out of range [0; %d[" % [p_start_index, _stored_count])
 			return 0
 
-		var max_write := min(p_values.size(), _stored_count - p_start_index)
-		for i in range(max_write):
-			var storage_i := _map_logical_to_storage(p_start_index + i)
-			_buffer[storage_i] = p_values[i]
+		# Optimization. The range is checked once, the ring origin is computed
+		# once, and the write is cut at the ring seam into two contiguous runs.
+		# Mapping each index on its own would repeat the check and the origin
+		# maths for every value.
+		#
+		# The write stays in place on purpose. Rebuilding the storage from
+		# slices would be one native copy, but it would allocate the whole
+		# buffer again, which is slower for the small writes a streaming plot
+		# makes.
+		var write_count := min(p_values.size(), _stored_count - p_start_index)
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := min(write_count, _capacity - start)
+		for i in range(head):
+			_buffer[start + i] = p_values[i]
+		for i in range(write_count - head):
+			_buffer[i] = p_values[head + i]
 
-		return max_write
+		return write_count
 
 
 	func append_value(p_value: int) -> int:
@@ -121,21 +170,12 @@ class Int32Buffer extends RefCounted:
 	# Private
 	####################################################################################################
 
-	# Negative when the logical index has no storage slot.
-	func _map_logical_to_storage(p_logical_index: int) -> int:
-		if _stored_count <= 0:
-			push_error("Int32Buffer: the buffer is empty")
-			return -1
-
-		if p_logical_index < 0 or p_logical_index >= _stored_count:
-			push_error("Int32Buffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
-			return -1
-
-		var oldest_storage := _storage_head - _stored_count
-		if oldest_storage < 0:
-			oldest_storage += _capacity
-
-		return (oldest_storage + p_logical_index) % _capacity
+	# Storage index of logical index 0. It checks nothing, so a bulk read or
+	# write can call it once before its loop and then index the storage
+	# directly. Callers check the logical range themselves.
+	func _storage_origin() -> int:
+		var origin := _storage_head - _stored_count
+		return origin + _capacity if origin < 0 else origin
 
 
 	static func _resize_ring_buffer(p_old: PackedInt32Array, p_old_cap: int, p_old_head: int, p_old_count: int, p_new_cap: int) -> PackedInt32Array:

--- a/addons/tau-plot/model/string_buffer.gd
+++ b/addons/tau-plot/model/string_buffer.gd
@@ -42,19 +42,56 @@ class StringBuffer extends RefCounted:
 
 
 	func get_value(p_logical_index: int) -> String:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("StringBuffer: the buffer is empty")
 			return ""
 
-		return _buffer[storage_i]
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("StringBuffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return ""
+
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	## Skips the range validation of get_value(). Outside [0; size()[ this reads
+	## an unrelated slot of the ring storage instead of reporting an error, so
+	## the caller must already hold the bound.
+	func get_value_unsafe(p_logical_index: int) -> String:
+		return _buffer[(_storage_origin() + p_logical_index) % _capacity]
+
+
+	func get_values(p_start_index: int, p_count: int) -> PackedStringArray:
+		if p_count <= 0:
+			return PackedStringArray()
+
+		if p_start_index < 0 or p_start_index + p_count > _stored_count:
+			push_error("StringBuffer: range [%d; %d[ out of range [0; %d[" % [p_start_index, p_start_index + p_count, _stored_count])
+			return PackedStringArray()
+
+		# Optimization. The range is validated once, the ring origin is computed
+		# once, and the read is split at the seam into at most two native
+		# slices. Reading element by element would cost a script iteration and
+		# an index mapping per value, which dominates on a large read.
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := _capacity - start
+		if p_count <= head:
+			return _buffer.slice(start, start + p_count)
+
+		var out := _buffer.slice(start, _capacity)
+		out.append_array(_buffer.slice(0, p_count - head))
+		return out
 
 
 	func set_value(p_logical_index: int, p_value: String) -> void:
-		var storage_i := _map_logical_to_storage(p_logical_index)
-		if storage_i < 0:
+		if _stored_count <= 0:
+			push_error("StringBuffer: the buffer is empty")
 			return
 
-		_buffer[storage_i] = p_value
+		if p_logical_index < 0 or p_logical_index >= _stored_count:
+			push_error("StringBuffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
+			return
+
+		_buffer[(_storage_origin() + p_logical_index) % _capacity] = p_value
 
 
 	func set_values(p_start_index: int, p_values: PackedStringArray) -> int:
@@ -69,12 +106,23 @@ class StringBuffer extends RefCounted:
 			push_error("StringBuffer: start_index %d out of range [0; %d[" % [p_start_index, _stored_count])
 			return 0
 
-		var max_write := min(p_values.size(), _stored_count - p_start_index)
-		for i in range(max_write):
-			var storage_i := _map_logical_to_storage(p_start_index + i)
-			_buffer[storage_i] = p_values[i]
+		# Optimization. The range is validated once, the ring origin is computed
+		# once, and the write is split at the seam into two contiguous runs.
+		# Mapping each logical index on its own would repeat both the validation
+		# and the origin arithmetic per element.
+		#
+		# The write stays in place on purpose. Rebuilding the storage from
+		# slices would be one native copy but would reallocate the whole buffer,
+		# which loses on the small writes a streaming plot makes.
+		var write_count := min(p_values.size(), _stored_count - p_start_index)
+		var start := (_storage_origin() + p_start_index) % _capacity
+		var head := min(write_count, _capacity - start)
+		for i in range(head):
+			_buffer[start + i] = p_values[i]
+		for i in range(write_count - head):
+			_buffer[i] = p_values[head + i]
 
-		return max_write
+		return write_count
 
 
 	func append_value(p_value: String) -> int:
@@ -120,21 +168,12 @@ class StringBuffer extends RefCounted:
 	# Private
 	####################################################################################################
 
-	# Negative when the logical index has no storage slot.
-	func _map_logical_to_storage(p_logical_index: int) -> int:
-		if _stored_count <= 0:
-			push_error("StringBuffer: the buffer is empty")
-			return -1
-
-		if p_logical_index < 0 or p_logical_index >= _stored_count:
-			push_error("StringBuffer: logical index %d out of range [0; %d[" % [p_logical_index, _stored_count])
-			return -1
-
-		var oldest_storage := _storage_head - _stored_count
-		if oldest_storage < 0:
-			oldest_storage += _capacity
-
-		return (oldest_storage + p_logical_index) % _capacity
+	# Storage index of logical index 0. Carries no validation so bulk paths can
+	# hoist it out of their loop and index the storage directly. Callers
+	# validate the logical range before using it.
+	func _storage_origin() -> int:
+		var origin := _storage_head - _stored_count
+		return origin + _capacity if origin < 0 else origin
 
 
 	static func _resize_ring_buffer(p_old: PackedStringArray, p_old_cap: int, p_old_head: int, p_old_count: int, p_new_cap: int) -> PackedStringArray:

--- a/addons/tau-plot/plot/xy/bar/bar_renderer.gd
+++ b/addons/tau-plot/plot/xy/bar/bar_renderer.gd
@@ -79,6 +79,11 @@ class BarRenderer extends Control:
 	# never drifts from what is on screen.
 	var _hit_records: Array[BarHitRecord] = []
 
+	# Optimization. Building one hit record per bar costs an allocation plus a
+	# screen mapping, and hit testing is the only reader. Dropping the cache
+	# when hover cannot reach this overlay removes both.
+	var _hit_records_enabled: bool = true
+
 
 	func _init(p_layout: XYLayout,
 				p_dataset: Dataset,
@@ -149,7 +154,17 @@ class BarRenderer extends Control:
 			queue_redraw()
 
 
-	## Returns the per-frame hit records cache. Treat as read-only.
+	## Enables or disables the per-frame hit record cache. While disabled,
+	## get_hit_records() returns an empty array and hover cannot resolve a sample
+	## on this overlay.
+	func set_hit_records_enabled(p_enabled: bool) -> void:
+		if _hit_records_enabled == p_enabled:
+			return
+		_hit_records_enabled = p_enabled
+		queue_redraw()
+
+
+	## Returns the per-frame hit records cache, empty while the cache is disabled.
 	func get_hit_records() -> Array[BarHitRecord]:
 		return _hit_records
 
@@ -472,7 +487,8 @@ class BarRenderer extends Control:
 
 
 	## Draws a single bar, orientation-aware, using a StyleBox.
-	## Records a BarHitRecord for every bar that survives clipping.
+	## Records a BarHitRecord for every bar that survives clipping, unless the
+	## hit record cache is disabled.
 	## p_pane_rect: pane bounds used to clip the bar rect.
 	## p_x_axis_px: bar center along the x-axis direction, in pixels.
 	## p_y_axis_from_px: baseline end of the bar along the y-axis direction, in pixels.
@@ -536,6 +552,9 @@ class BarRenderer extends Control:
 			_remap_corners_and_borders(style_box as StyleBoxFlat, _derived_source_ref as StyleBoxFlat, x_is_horizontal, tip_at_min)
 
 		draw_style_box(style_box, rect)
+
+		if not _hit_records_enabled:
+			return
 
 		# Tip center in screen coords, un-clipped so the anchor stays on the data
 		# point even when the bar is partly outside the pane.

--- a/addons/tau-plot/plot/xy/hover/hover_controller.gd
+++ b/addons/tau-plot/plot/xy/hover/hover_controller.gd
@@ -85,6 +85,7 @@ class HoverController extends RefCounted:
 		_hover_config = p_config
 
 		_apply_to_pane_renderers()
+		refresh_hit_records_enabled()
 		_resolve_tooltip_style()
 		_resolve_crosshair_style()
 		_create_crosshair_overlays()
@@ -124,8 +125,24 @@ class HoverController extends RefCounted:
 			return
 		_enabled = p_enabled
 		_apply_to_pane_renderers()
+		refresh_hit_records_enabled()
 		if not _enabled:
 			invalidate()
+
+
+	## Enables the hit record cache on every overlay renderer when hover is on
+	## and the overlay config is hoverable. Disables it otherwise, so the
+	## renderer stops building records no one reads.
+	func refresh_hit_records_enabled() -> void:
+		for renderer: BarRenderer in _bar_renderers:
+			if renderer == null:
+				continue  # Pane has no bar overlay.
+			renderer.set_hit_records_enabled(_enabled and renderer.get_config().hoverable)
+
+		for renderer: LineRenderer in _line_renderers:
+			if renderer == null:
+				continue  # Pane has no line overlay.
+			renderer.set_hit_records_enabled(_enabled and renderer.get_config().hoverable)
 
 
 	## Replaces the TauHoverConfig at runtime and re-resolves styles.

--- a/addons/tau-plot/plot/xy/line/line_renderer.gd
+++ b/addons/tau-plot/plot/xy/line/line_renderer.gd
@@ -368,6 +368,7 @@ class LineRenderer extends Control:
 		var series_id: int = -1
 		var global_index: int = -1
 		var y_axis_id: AxisId
+		var y_mapping: XYLayout.AxisMapping = null
 		var x_is_log: bool = false
 		var y_is_log: bool = false
 		var color_buffer: VisualAttributes.ColorBuffer = null
@@ -391,6 +392,7 @@ class LineRenderer extends Control:
 		ctx.series_id = _get_line_series_id(p_series_index)
 		ctx.global_index = _get_global_series_index(p_series_index)
 		ctx.y_axis_id = _get_y_axis_id_for_series(ctx.series_id)
+		ctx.y_mapping = _layout.get_y_mapping(_pane_index, ctx.y_axis_id)
 		ctx.x_is_log = _get_x_axis_config().scale == TauAxisConfig.Scale.LOGARITHMIC
 		ctx.y_is_log = _get_y_axis_config(ctx.y_axis_id).scale == TauAxisConfig.Scale.LOGARITHMIC
 
@@ -469,6 +471,11 @@ class LineRenderer extends Control:
 		else:
 			x_values = _dataset.get_series_x_numeric_slice(p_ctx.series_id, 0, sample_count)
 
+		# Optimization. The x transform is looked up once and applied per value.
+		# Going through map_x_to_px would add a call and a pane lookup per
+		# sample for a transform fixed across the whole row.
+		var x_mapping := _layout.get_x_mapping(_pane_index)
+
 		var x_px := PackedFloat64Array()
 		x_px.resize(sample_count)
 		for i in range(sample_count):
@@ -476,7 +483,7 @@ class LineRenderer extends Control:
 			if not is_finite(xv) or (p_ctx.x_is_log and xv <= 0.0):
 				x_px[i] = NAN
 			else:
-				x_px[i] = _layout.map_x_to_px(_pane_index, xv)
+				x_px[i] = x_mapping.to_px(xv)
 
 		_draw_series_runs(p_ctx, p_stacked, x_px, x_values)
 
@@ -574,7 +581,7 @@ class LineRenderer extends Control:
 					real_dataset_indices = PackedInt32Array()
 				continue
 
-			var y_px := _layout.map_y_to_px(_pane_index, y_plotted, y_axis_id)
+			var y_px := p_ctx.y_mapping.to_px(y_plotted)
 			var axis_point := Vector2(x_px, y_px)
 			var x_value: Variant = p_x_values[i]
 			var sample_color := _resolve_sample_color(p_ctx, i, x_value, y_raw)
@@ -584,7 +591,7 @@ class LineRenderer extends Control:
 			# Lower edge in lockstep: same x, dropped to the layer below's top. The
 			# shared step-riser logic keeps it index-aligned with the upper run.
 			if stacked_fill:
-				var baseline_axis_point := Vector2(x_px, _layout.map_y_to_px(_pane_index, p_stacked.get_y_baseline(p_ctx.series_index, i), y_axis_id))
+				var baseline_axis_point := Vector2(x_px, p_ctx.y_mapping.to_px(p_stacked.get_y_baseline(p_ctx.series_index, i)))
 				_append_lower_with_interpolation(run_baseline, baseline_axis_point, interpolation)
 			# The real sample is always the last vertex appended by
 			# _append_with_interpolation, regardless of the interpolation mode.

--- a/addons/tau-plot/plot/xy/line/line_renderer.gd
+++ b/addons/tau-plot/plot/xy/line/line_renderer.gd
@@ -3,7 +3,6 @@ const Dataset := preload("res://addons/tau-plot/model/dataset.gd").Dataset
 const XYLayout := preload("res://addons/tau-plot/plot/xy/xy_layout.gd").XYLayout
 const SeriesAxisAssignment := preload("res://addons/tau-plot/plot/xy/series_axis_assignment.gd").SeriesAxisAssignment
 const AxisId := preload("res://addons/tau-plot/plot/xy/xy_axes.gd").AxisId
-const Axis := preload("res://addons/tau-plot/plot/xy/xy_axes.gd").Axis
 const VisualAttributes := preload("res://addons/tau-plot/plot/xy/visual_attributes.gd").VisualAttributes
 const LineVisualAttributes := preload("res://addons/tau-plot/plot/xy/line/line_visual_attributes.gd").LineVisualAttributes
 const LineHitRecord := preload("res://addons/tau-plot/plot/xy/line/line_hit_record.gd").LineHitRecord
@@ -360,6 +359,59 @@ class LineRenderer extends Control:
 		RenderingServer.canvas_item_set_custom_rect(get_canvas_item(), true, p_pane_rect)
 
 
+	# Optimization. Holds every value the sample loop needs that is fixed for
+	# the whole series. Resolving them inline would walk the config, the
+	# resolved style and the axis assignment once per sample, which is the bulk
+	# of a redraw. Resolved fresh in each _draw() so it cannot go stale.
+	class _SeriesDrawContext extends RefCounted:
+		var series_index: int = -1
+		var series_id: int = -1
+		var global_index: int = -1
+		var y_axis_id: AxisId
+		var x_is_log: bool = false
+		var y_is_log: bool = false
+		var color_buffer: VisualAttributes.ColorBuffer = null
+		var alpha_buffer: VisualAttributes.AlphaBuffer = null
+		# Buffers may be shorter than the series, so the size is a real bound
+		# and not a redundant check. Cached here to keep it out of the sample
+		# loop.
+		var color_buffer_size: int = 0
+		var alpha_buffer_size: int = 0
+		var color_callback: Callable = Callable()
+		var alpha_callback: Callable = Callable()
+		var has_color_callback: bool = false
+		var has_alpha_callback: bool = false
+		var base_color: Color
+		var base_alpha: float = 1.0
+
+
+	func _build_series_draw_context(p_series_index: int) -> _SeriesDrawContext:
+		var ctx := _SeriesDrawContext.new()
+		ctx.series_index = p_series_index
+		ctx.series_id = _get_line_series_id(p_series_index)
+		ctx.global_index = _get_global_series_index(p_series_index)
+		ctx.y_axis_id = _get_y_axis_id_for_series(ctx.series_id)
+		ctx.x_is_log = _get_x_axis_config().scale == TauAxisConfig.Scale.LOGARITHMIC
+		ctx.y_is_log = _get_y_axis_config(ctx.y_axis_id).scale == TauAxisConfig.Scale.LOGARITHMIC
+
+		var attributes: LineVisualAttributes = _visual_attributes[p_series_index]
+		ctx.color_buffer = attributes.color_buffer
+		ctx.alpha_buffer = attributes.alpha_buffer
+		ctx.color_buffer_size = ctx.color_buffer.size() if ctx.color_buffer != null else 0
+		ctx.alpha_buffer_size = ctx.alpha_buffer.size() if ctx.alpha_buffer != null else 0
+
+		var callbacks := _line_config.line_visual_callbacks
+		if callbacks != null:
+			ctx.color_callback = callbacks.color_callback
+			ctx.alpha_callback = callbacks.alpha_callback
+			ctx.has_color_callback = ctx.color_callback.is_valid()
+			ctx.has_alpha_callback = ctx.alpha_callback.is_valid()
+
+		ctx.base_color = _xy_style.get_series_color(ctx.global_index)
+		ctx.base_alpha = _xy_style.get_series_alpha(ctx.global_index)
+		return ctx
+
+
 	# Routes a series to the x layout that resolves its parameter axis, then the
 	# shared run loop applies the emission rules for both:
 	#   - A valid sample is appended to the current run.
@@ -375,13 +427,14 @@ class LineRenderer extends Control:
 	# runs the full path: a series at width 0 still fills and still answers
 	# hover on its samples.
 	func _draw_series(p_series_index: int, p_stacked: StackedSeriesValues) -> void:
-		if not _series_paints_anything(p_series_index):
+		var ctx := _build_series_draw_context(p_series_index)
+		if not _series_paints_anything(ctx.global_index):
 			return
 
 		if _get_x_axis_config().type == TauAxisConfig.Type.CATEGORICAL:
-			_draw_series_categorical(p_series_index, p_stacked)
+			_draw_series_categorical(ctx, p_stacked)
 		else:
-			_draw_series_continuous(p_series_index, p_stacked)
+			_draw_series_continuous(ctx, p_stacked)
 
 
 	# True when the series puts at least one of its two marks on screen, a
@@ -390,47 +443,42 @@ class LineRenderer extends Control:
 	# whole series is invisible. The fill resolved here is the same one
 	# _draw_series_runs resolves for the run loop, both cheap reads off the
 	# resolved style.
-	func _series_paints_anything(p_series_index: int) -> bool:
-		var global_series_index := _get_global_series_index(p_series_index)
-		if _line_style.get_series_width_px(global_series_index) > 0.0:
+	func _series_paints_anything(p_global_series_index: int) -> bool:
+		if _line_style.get_series_width_px(p_global_series_index) > 0.0:
 			return true
-		var fill: TauLineFill = _line_style.get_series_fill(global_series_index)
-		return resolve_series_fill_color(global_series_index, fill).a > 0.0
+		var fill: TauLineFill = _line_style.get_series_fill(p_global_series_index)
+		return resolve_series_fill_color(p_global_series_index, fill).a > 0.0
 
 
-	func _draw_series_continuous(p_series_index: int, p_stacked: StackedSeriesValues) -> void:
-		var series_id := _get_line_series_id(p_series_index)
-
+	func _draw_series_continuous(p_ctx: _SeriesDrawContext, p_stacked: StackedSeriesValues) -> void:
 		# Precompute the x plan for the shared run loop. A sample whose x is NaN,
 		# Inf, or forbidden by the axis scale gets a NAN x pixel, which the loop
 		# reads as a run break. Every other sample maps its x to an axis pixel.
 		# The value stored alongside is the raw float, handed to color resolution
 		# and hit records unchanged.
 		var is_shared_x := _dataset.get_mode() == Dataset.Mode.SHARED_X
-		var sample_count := _dataset.get_series_sample_count(series_id)
+		var sample_count := _dataset.get_series_sample_count(p_ctx.series_id)
 		var x_px := PackedFloat64Array()
 		x_px.resize(sample_count)
 		var x_values: Array = []
 		x_values.resize(sample_count)
 		for i in range(sample_count):
-			var xv: float = float(_dataset.get_shared_x(i)) if is_shared_x else float(_dataset.get_series_x(series_id, i))
+			var xv: float = float(_dataset.get_shared_x(i)) if is_shared_x else float(_dataset.get_series_x(p_ctx.series_id, i))
 			x_values[i] = xv
-			if is_nan(xv) or is_inf(xv) or not _is_x_value_valid_for_scale(xv):
+			if is_nan(xv) or is_inf(xv) or (p_ctx.x_is_log and xv <= 0.0):
 				x_px[i] = NAN
 			else:
 				x_px[i] = _layout.map_x_to_px(_pane_index, xv)
 
-		_draw_series_runs(p_series_index, p_stacked, x_px, x_values)
+		_draw_series_runs(p_ctx, p_stacked, x_px, x_values)
 
 
-	func _draw_series_categorical(p_series_index: int, p_stacked: StackedSeriesValues) -> void:
-		var series_id := _get_line_series_id(p_series_index)
-
+	func _draw_series_categorical(p_ctx: _SeriesDrawContext, p_stacked: StackedSeriesValues) -> void:
 		# Precompute the x plan for the shared run loop. Category centers are
 		# always valid, so no x pixel is ever NAN and a run only breaks on an
 		# invalid y. The value stored alongside is the category itself.
 		var categories := _layout.domain.x_categories
-		var sample_count := _dataset.get_series_sample_count(series_id)
+		var sample_count := _dataset.get_series_sample_count(p_ctx.series_id)
 		var x_px := PackedFloat64Array()
 		x_px.resize(sample_count)
 		var x_values: Array = []
@@ -439,7 +487,7 @@ class LineRenderer extends Control:
 			x_px[cat_idx] = _layout.map_x_category_center_to_px(_pane_index, cat_idx)
 			x_values[cat_idx] = categories[cat_idx]
 
-		_draw_series_runs(p_series_index, p_stacked, x_px, x_values)
+		_draw_series_runs(p_ctx, p_stacked, x_px, x_values)
 
 
 	# Builds and finalizes every run of one series from a precomputed x plan,
@@ -449,20 +497,19 @@ class LineRenderer extends Control:
 	# value handed to color resolution and hit records, a float for a continuous
 	# x and a category for a categorical one. The y plan (scale validity,
 	# stacking, normalization) is resolved here per sample.
-	func _draw_series_runs(p_series_index: int, p_stacked: StackedSeriesValues, p_x_px: PackedFloat64Array, p_x_values: Array) -> void:
-		var series_id := _get_line_series_id(p_series_index)
-		var global_series_index := _get_global_series_index(p_series_index)
-		var width_px: float = _line_style.get_series_width_px(global_series_index)
-		var dash_px: int = _line_style.get_series_dash_length_px(global_series_index)
-		var hover_width_px: float = max(_line_style.get_series_hovered_width_px(global_series_index), width_px)
-		var y_axis_id := _get_y_axis_id_for_series(series_id)
+	func _draw_series_runs(p_ctx: _SeriesDrawContext, p_stacked: StackedSeriesValues, p_x_px: PackedFloat64Array, p_x_values: Array) -> void:
+		var series_id := p_ctx.series_id
+		var width_px: float = _line_style.get_series_width_px(p_ctx.global_index)
+		var dash_px: int = _line_style.get_series_dash_length_px(p_ctx.global_index)
+		var hover_width_px: float = max(_line_style.get_series_hovered_width_px(p_ctx.global_index), width_px)
+		var y_axis_id := p_ctx.y_axis_id
 		var bridge: bool = _line_config.gap_policy == TauLineConfig.GapPolicy.BRIDGE
-		var interpolation: TauLineConfig.InterpolationMode = _line_config.get_series_interpolation_mode(global_series_index)
+		var interpolation: TauLineConfig.InterpolationMode = _line_config.get_series_interpolation_mode(p_ctx.global_index)
 
 		# Resolved once per series: every run of this series fills against the
 		# same baseline and the same color, and uses the same UV reference frame.
-		var fill: TauLineFill = _line_style.get_series_fill(global_series_index)
-		var fill_color: Color = resolve_series_fill_color(global_series_index, fill)
+		var fill: TauLineFill = _line_style.get_series_fill(p_ctx.global_index)
+		var fill_color: Color = resolve_series_fill_color(p_ctx.global_index, fill)
 		var baseline_y_px: float = _resolve_fill_baseline_y_px(fill, y_axis_id)
 		var fill_uv_ctx: _FillUVContext = _resolve_fill_uv_context(fill, y_axis_id)
 
@@ -474,7 +521,7 @@ class LineRenderer extends Control:
 
 		var independent_y: PackedFloat64Array
 		if p_stacked == null:
-			independent_y = _build_independent_y_row(series_id)
+			independent_y = _build_independent_y_row(p_ctx)
 
 		var run := PackedVector2Array()
 		var run_colors := PackedColorArray()
@@ -498,8 +545,8 @@ class LineRenderer extends Control:
 			var y_raw: float = NAN
 			if not is_nan(x_px):
 				if p_stacked != null:
-					y_plotted = p_stacked.get_y_plotted(p_series_index, i)
-					y_raw = p_stacked.get_y_raw(p_series_index, i)
+					y_plotted = p_stacked.get_y_plotted(p_ctx.series_index, i)
+					y_raw = p_stacked.get_y_raw(p_ctx.series_index, i)
 				else:
 					y_plotted = independent_y[i]
 					y_raw = y_plotted
@@ -520,14 +567,14 @@ class LineRenderer extends Control:
 			var y_px := _layout.map_y_to_px(_pane_index, y_plotted, y_axis_id)
 			var axis_point := Vector2(x_px, y_px)
 			var x_value: Variant = p_x_values[i]
-			var sample_color := _resolve_sample_color(p_series_index, i, x_value, y_raw)
+			var sample_color := _resolve_sample_color(p_ctx, i, x_value, y_raw)
 			# The run is buffered in axis space so interpolation runs along the
 			# parameter and value axes directly. _finalize_run maps it to screen.
 			_append_with_interpolation(run, run_colors, axis_point, sample_color, interpolation)
 			# Lower edge in lockstep: same x, dropped to the layer below's top. The
 			# shared step-riser logic keeps it index-aligned with the upper run.
 			if stacked_fill:
-				var baseline_axis_point := Vector2(x_px, _layout.map_y_to_px(_pane_index, p_stacked.get_y_baseline(p_series_index, i), y_axis_id))
+				var baseline_axis_point := Vector2(x_px, _layout.map_y_to_px(_pane_index, p_stacked.get_y_baseline(p_ctx.series_index, i), y_axis_id))
 				_append_lower_with_interpolation(run_baseline, baseline_axis_point, interpolation)
 			# The real sample is always the last vertex appended by
 			# _append_with_interpolation, regardless of the interpolation mode.
@@ -549,16 +596,16 @@ class LineRenderer extends Control:
 
 	# Marks dropped samples (NaN, Inf, log-axis violations) as NAN up front
 	# so the inner draw loop only needs a single is_nan() check per sample.
-	func _build_independent_y_row(p_series_id: int) -> PackedFloat64Array:
-		var sample_count := _dataset.get_series_sample_count(p_series_id)
+	func _build_independent_y_row(p_ctx: _SeriesDrawContext) -> PackedFloat64Array:
+		var sample_count := _dataset.get_series_sample_count(p_ctx.series_id)
 		var y_plotted := PackedFloat64Array()
 		y_plotted.resize(sample_count)
 		y_plotted.fill(NAN)
 		for i in range(sample_count):
-			var y := _dataset.get_series_y(p_series_id, i)
+			var y := _dataset.get_series_y(p_ctx.series_id, i)
 			if is_nan(y) or is_inf(y):
 				continue
-			if not _is_y_value_valid_for_scale(p_series_id, y):
+			if p_ctx.y_is_log and y <= 0.0:
 				continue
 			y_plotted[i] = y
 		return y_plotted
@@ -1647,8 +1694,7 @@ class LineRenderer extends Control:
 				return window_swapped != _get_x_axis_config().inverted
 			TauLineFill.FillStretchSpan.VALUE_Y:
 				var series_id: int = _dataset.get_series_id_by_index(p_global_series_index)
-				var pane_cfg: TauPaneConfig = _layout.domain.config.panes[_pane_index]
-				var y_cfg: TauAxisConfig = pane_cfg.get_y_axis_config(_get_y_axis_id_for_series(series_id))
+				var y_cfg := _get_y_axis_config(_get_y_axis_id_for_series(series_id))
 				return window_swapped != y_cfg.inverted
 			TauLineFill.FillStretchSpan.MAGNITUDE:
 				return window_swapped
@@ -1946,86 +1992,77 @@ class LineRenderer extends Control:
 	# Combined per-sample color resolution. Alpha overwrites the resolved
 	# color's alpha channel, then the result is routed through the
 	# hover-highlight callback when active.
-	func _resolve_sample_color(p_series_index: int, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> Color:
-		var base := _resolve_sample_color_only(p_series_index, p_sample_index, p_x_value, p_y_value)
-		var alpha := _resolve_sample_alpha(p_series_index, p_sample_index, p_x_value, p_y_value)
+	#
+	# Optimization. The highlight routing is inlined rather than delegated. A
+	# helper would cost a call per sample to return its argument unchanged on
+	# the path where no highlight is active.
+	func _resolve_sample_color(p_ctx: _SeriesDrawContext, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> Color:
+		var base := _resolve_sample_color_only(p_ctx, p_sample_index, p_x_value, p_y_value)
+		var alpha := _resolve_sample_alpha(p_ctx, p_sample_index, p_x_value, p_y_value)
 		base.a = clampf(alpha, 0.0, 1.0)
-		return _apply_hover_color(base, _get_line_series_id(p_series_index), p_sample_index)
-
-
-	# Applies the hover-highlight callback (or the built-in dim/brighten
-	# default) to a resolved per-sample color. Returns the color unchanged
-	# when the highlight feature is off.
-	func _apply_hover_color(p_color: Color, p_series_id: int, p_sample_index: int) -> Color:
 		if not _highlight_active:
-			return p_color
-		var is_hovered: bool = (p_series_id == _hovered_series_id) and (p_sample_index == _hovered_sample_index)
-		return HoverHighlight.resolve(p_color, is_hovered, _hover_highlight_callback)
+			return base
+		var is_hovered: bool = (p_ctx.series_id == _hovered_series_id) and (p_sample_index == _hovered_sample_index)
+		return HoverHighlight.resolve(base, is_hovered, _hover_highlight_callback)
 
 
-	func _resolve_sample_color_only(p_series_index: int, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> Color:
-		# Per-sample override from LineVisualAttributes.color_buffer.
-		var color_buffer: VisualAttributes.ColorBuffer = _visual_attributes[p_series_index].color_buffer
-		if color_buffer != null and p_sample_index >= 0 and p_sample_index < color_buffer.size():
-			var c := color_buffer.get_value(p_sample_index)
+	func _resolve_sample_color_only(p_ctx: _SeriesDrawContext, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> Color:
+		# Per-sample override from LineVisualAttributes.color_buffer. The lower
+		# bound is guaranteed by the sample loop. The upper one is real: a
+		# buffer shorter than the series falls through to the resolved style.
+		if p_ctx.color_buffer != null and p_sample_index < p_ctx.color_buffer_size:
+			var c := p_ctx.color_buffer.get_value(p_sample_index)
 			if c != VisualAttributes.ColorBuffer.NO_COLOR:
 				return c
-
-		var global_series_index := _get_global_series_index(p_series_index)
 
 		# Per-sample override from LineVisualCallbacks.color_callback.
-		var vc := _line_config.line_visual_callbacks
-		if vc != null and vc.color_callback.is_valid():
-			var c: Color = vc.color_callback.call(global_series_index, p_sample_index, p_x_value, p_y_value)
+		if p_ctx.has_color_callback:
+			var c: Color = p_ctx.color_callback.call(p_ctx.global_index, p_sample_index, p_x_value, p_y_value)
 			if c != VisualAttributes.ColorBuffer.NO_COLOR:
 				return c
 
-		return _xy_style.get_series_color(global_series_index)
+		return p_ctx.base_color
 
 
-	func _resolve_sample_alpha(p_series_index: int, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> float:
-		# Per-sample override from LineVisualAttributes.alpha_buffer.
-		var alpha_buffer: VisualAttributes.AlphaBuffer = _visual_attributes[p_series_index].alpha_buffer
-		if alpha_buffer != null and p_sample_index >= 0 and p_sample_index < alpha_buffer.size():
-			var a := alpha_buffer.get_value(p_sample_index)
+	func _resolve_sample_alpha(p_ctx: _SeriesDrawContext, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> float:
+		# Per-sample override from LineVisualAttributes.alpha_buffer, bounded
+		# like the color buffer.
+		if p_ctx.alpha_buffer != null and p_sample_index < p_ctx.alpha_buffer_size:
+			var a := p_ctx.alpha_buffer.get_value(p_sample_index)
 			if a >= 0.0:
 				return a
-
-		var global_series_index := _get_global_series_index(p_series_index)
 
 		# Per-sample override from LineVisualCallbacks.alpha_callback.
-		var vc := _line_config.line_visual_callbacks
-		if vc != null and vc.alpha_callback.is_valid():
-			var a: float = vc.alpha_callback.call(global_series_index, p_sample_index, p_x_value, p_y_value)
+		if p_ctx.has_alpha_callback:
+			var a: float = p_ctx.alpha_callback.call(p_ctx.global_index, p_sample_index, p_x_value, p_y_value)
 			if a >= 0.0:
 				return a
 
-		return _xy_style.get_series_alpha(global_series_index)
+		return p_ctx.base_alpha
 
 
 	####################################################################################################
 	# Axis helpers
 	####################################################################################################
 
+	# XYPlotValidator rejects a binding whose y axis is not orthogonal to the x
+	# axis or whose pane has no axis configured there, and _line_series_ids is
+	# built from the surviving bindings, so the assignment always answers.
 	func _get_y_axis_id_for_series(p_series_id: int) -> AxisId:
-		var axis_id: int = _series_assignment.get_y_axis_id_for_series(p_series_id, _pane_index)
-		if axis_id != -1:
-			return axis_id as AxisId
-		# Fallback: should not happen if validation passed.
-		push_error("LineRenderer: series %d not assigned to any y-axis in pane %d" % [p_series_id, _pane_index])
-		return Axis.get_orthogonal_axes(_layout.domain.config.x_axis_id)[0]
+		return _series_assignment.get_y_axis_id_for_series(p_series_id, _pane_index) as AxisId
+
+
+	# Returns the config of one y axis of this renderer's pane.
+	func _get_y_axis_config(p_y_axis_id: AxisId) -> TauAxisConfig:
+		var pane_cfg: TauPaneConfig = _layout.domain.config.panes[_pane_index]
+		return pane_cfg.get_y_axis_config(p_y_axis_id)
 
 
 	####################################################################################################
 	# Axis-scale validity checks
 	####################################################################################################
 
-	func _is_x_value_valid_for_scale(p_x_value: float) -> bool:
-		return _layout.domain.config.x_axis.scale != TauAxisConfig.Scale.LOGARITHMIC or p_x_value > 0.0
-
-
+	# The draw path reads the resolved scale off the per-series context instead.
 	func _is_y_value_valid_for_scale(p_series_id: int, p_y_value: float) -> bool:
-		var y_axis_id := _get_y_axis_id_for_series(p_series_id)
-		var pane_cfg: TauPaneConfig = _layout.domain.config.panes[_pane_index]
-		var y_cfg: TauAxisConfig = pane_cfg.get_y_axis_config(y_axis_id)
+		var y_cfg := _get_y_axis_config(_get_y_axis_id_for_series(p_series_id))
 		return y_cfg.scale != TauAxisConfig.Scale.LOGARITHMIC or p_y_value > 0.0

--- a/addons/tau-plot/plot/xy/line/line_renderer.gd
+++ b/addons/tau-plot/plot/xy/line/line_renderer.gd
@@ -72,6 +72,7 @@ const HoverHighlight := preload("res://addons/tau-plot/plot/xy/hover/hover_highl
 #   Each part is one draw call. For dashed lines, each part inherits the
 #   cumulative arc-length offset from the polyline start, so the dash
 #   pattern stays continuous through the slices.
+# - The hit record cache is gated by set_hit_records_enabled().
 #
 # Per-sample color and alpha resolution:
 # - Color resolution order: LineVisualAttributes.color_buffer, then
@@ -193,6 +194,11 @@ class LineRenderer extends Control:
 	# Rebuilt every _draw() so the cache never drifts from what is on screen.
 	var _hit_records: Array[LineHitRecord] = []
 
+	# Optimization. Building one hit record per sample is the largest single cost
+	# of a redraw, and hit testing is the only reader. Dropping the cache when
+	# hover cannot reach this overlay removes an allocation per sample.
+	var _hit_records_enabled: bool = true
+
 	# Hover highlight state. When _highlight_active is true, the per-sample
 	# color is routed through the hover color callback (or a built-in
 	# dim/brighten default). When the hovered sample lies within a drawn
@@ -266,7 +272,17 @@ class LineRenderer extends Control:
 			queue_redraw()
 
 
-	## Returns the per-frame hit records cache. Treat as read-only.
+	## Enables or disables the per-frame hit record cache. While disabled,
+	## get_hit_records() returns an empty array and hover cannot resolve a sample
+	## on this overlay.
+	func set_hit_records_enabled(p_enabled: bool) -> void:
+		if _hit_records_enabled == p_enabled:
+			return
+		_hit_records_enabled = p_enabled
+		queue_redraw()
+
+
+	## Returns the per-frame hit records cache, empty while the cache is disabled.
 	func get_hit_records() -> Array[LineHitRecord]:
 		return _hit_records
 
@@ -503,7 +519,6 @@ class LineRenderer extends Control:
 
 			var y_px := _layout.map_y_to_px(_pane_index, y_plotted, y_axis_id)
 			var axis_point := Vector2(x_px, y_px)
-			var screen_pos := _layout.map_point_to_screen(x_px, y_px)
 			var x_value: Variant = p_x_values[i]
 			var sample_color := _resolve_sample_color(p_series_index, i, x_value, y_raw)
 			# The run is buffered in axis space so interpolation runs along the
@@ -519,14 +534,15 @@ class LineRenderer extends Control:
 			real_polyline_indices.append(run.size() - 1)
 			real_dataset_indices.append(i)
 
-			var record := LineHitRecord.new()
-			record.series_id = series_id
-			record.sample_index = i
-			record.x_value = x_value
-			record.y_plotted_value = y_plotted
-			record.y_raw_value = y_raw
-			record.screen_position = screen_pos
-			_hit_records.append(record)
+			if _hit_records_enabled:
+				var record := LineHitRecord.new()
+				record.series_id = series_id
+				record.sample_index = i
+				record.x_value = x_value
+				record.y_plotted_value = y_plotted
+				record.y_raw_value = y_raw
+				record.screen_position = _layout.map_point_to_screen(x_px, y_px)
+				_hit_records.append(record)
 
 		_finalize_run(run, run_colors, run_baseline, real_polyline_indices, real_dataset_indices, series_id, width_px, hover_width_px, interpolation, dash_px, fill, fill_color, baseline_y_px, fill_uv_ctx)
 

--- a/addons/tau-plot/plot/xy/line/line_renderer.gd
+++ b/addons/tau-plot/plot/xy/line/line_renderer.gd
@@ -372,8 +372,8 @@ class LineRenderer extends Control:
 		var y_is_log: bool = false
 		var color_buffer: VisualAttributes.ColorBuffer = null
 		var alpha_buffer: VisualAttributes.AlphaBuffer = null
-		# Buffers may be shorter than the series, so the size is a real bound
-		# and not a redundant check. Cached here to keep it out of the sample
+		# A buffer may be shorter than the series, so its size is a real limit
+		# and not a useless check. Read once here to keep it out of the sample
 		# loop.
 		var color_buffer_size: int = 0
 		var alpha_buffer_size: int = 0
@@ -454,18 +454,26 @@ class LineRenderer extends Control:
 		# Precompute the x plan for the shared run loop. A sample whose x is NaN,
 		# Inf, or forbidden by the axis scale gets a NAN x pixel, which the loop
 		# reads as a run break. Every other sample maps its x to an axis pixel.
-		# The value stored alongside is the raw float, handed to color resolution
-		# and hit records unchanged.
-		var is_shared_x := _dataset.get_mode() == Dataset.Mode.SHARED_X
+		# The row carried alongside holds the raw values, passed to color
+		# resolution and hit records unchanged.
 		var sample_count := _dataset.get_series_sample_count(p_ctx.series_id)
+
+		# Optimization. The whole x row is read in one call and scanned as a
+		# packed array, then passed to the run loop as it is. Reading one sample
+		# at a time would cost a mode check, a series lookup, a ring mapping and
+		# a Variant conversion for every value. Copying the row into a second
+		# array would then copy every value a second time.
+		var x_values: PackedFloat64Array
+		if _dataset.get_mode() == Dataset.Mode.SHARED_X:
+			x_values = _dataset.get_shared_x_numeric_slice(0, sample_count)
+		else:
+			x_values = _dataset.get_series_x_numeric_slice(p_ctx.series_id, 0, sample_count)
+
 		var x_px := PackedFloat64Array()
 		x_px.resize(sample_count)
-		var x_values: Array = []
-		x_values.resize(sample_count)
 		for i in range(sample_count):
-			var xv: float = float(_dataset.get_shared_x(i)) if is_shared_x else float(_dataset.get_series_x(p_ctx.series_id, i))
-			x_values[i] = xv
-			if is_nan(xv) or is_inf(xv) or (p_ctx.x_is_log and xv <= 0.0):
+			var xv := x_values[i]
+			if not is_finite(xv) or (p_ctx.x_is_log and xv <= 0.0):
 				x_px[i] = NAN
 			else:
 				x_px[i] = _layout.map_x_to_px(_pane_index, xv)
@@ -476,18 +484,17 @@ class LineRenderer extends Control:
 	func _draw_series_categorical(p_ctx: _SeriesDrawContext, p_stacked: StackedSeriesValues) -> void:
 		# Precompute the x plan for the shared run loop. Category centers are
 		# always valid, so no x pixel is ever NAN and a run only breaks on an
-		# invalid y. The value stored alongside is the category itself.
-		var categories := _layout.domain.x_categories
+		# invalid y. The row carried alongside holds the categories.
 		var sample_count := _dataset.get_series_sample_count(p_ctx.series_id)
 		var x_px := PackedFloat64Array()
 		x_px.resize(sample_count)
-		var x_values: Array = []
-		x_values.resize(sample_count)
 		for cat_idx in range(sample_count):
 			x_px[cat_idx] = _layout.map_x_category_center_to_px(_pane_index, cat_idx)
-			x_values[cat_idx] = categories[cat_idx]
 
-		_draw_series_runs(p_ctx, p_stacked, x_px, x_values)
+		# Optimization. The domain row is passed to the run loop as it is. The
+		# run loop only reads it, so copying it into a second array would
+		# duplicate every category for nothing.
+		_draw_series_runs(p_ctx, p_stacked, x_px, _layout.domain.x_categories)
 
 
 	# Builds and finalizes every run of one series from a precomputed x plan,
@@ -495,9 +502,11 @@ class LineRenderer extends Control:
 	# emission rules live in one place. p_x_px carries the axis-space x pixel per
 	# sample, NAN where the sample's x breaks the run. p_x_values carries the
 	# value handed to color resolution and hit records, a float for a continuous
-	# x and a category for a categorical one. The y plan (scale validity,
-	# stacking, normalization) is resolved here per sample.
-	func _draw_series_runs(p_ctx: _SeriesDrawContext, p_stacked: StackedSeriesValues, p_x_px: PackedFloat64Array, p_x_values: Array) -> void:
+	# x and a category for a categorical one. It is the row the layout already
+	# holds, a PackedFloat64Array or a PackedStringArray, so the type is
+	# Variant. The y plan (scale validity, stacking, normalization) is resolved
+	# here per sample.
+	func _draw_series_runs(p_ctx: _SeriesDrawContext, p_stacked: StackedSeriesValues, p_x_px: PackedFloat64Array, p_x_values: Variant) -> void:
 		var series_id := p_ctx.series_id
 		var width_px: float = _line_style.get_series_width_px(p_ctx.global_index)
 		var dash_px: int = _line_style.get_series_dash_length_px(p_ctx.global_index)
@@ -519,9 +528,11 @@ class LineRenderer extends Control:
 		# lower run empty and unused.
 		var stacked_fill: bool = fill.fill_mode == TauLineFill.FillMode.STACKED and p_stacked != null
 
+		var sample_count := p_x_px.size()
+
 		var independent_y: PackedFloat64Array
 		if p_stacked == null:
-			independent_y = _build_independent_y_row(p_ctx)
+			independent_y = _build_independent_y_row(p_ctx, sample_count)
 
 		var run := PackedVector2Array()
 		var run_colors := PackedColorArray()
@@ -536,7 +547,6 @@ class LineRenderer extends Control:
 		var real_polyline_indices := PackedInt32Array()
 		var real_dataset_indices := PackedInt32Array()
 
-		var sample_count := p_x_px.size()
 		for i in range(sample_count):
 			var x_px: float = p_x_px[i]
 			# The y plan is only read for an x-valid sample, so an invalid x
@@ -594,20 +604,24 @@ class LineRenderer extends Control:
 		_finalize_run(run, run_colors, run_baseline, real_polyline_indices, real_dataset_indices, series_id, width_px, hover_width_px, interpolation, dash_px, fill, fill_color, baseline_y_px, fill_uv_ctx)
 
 
-	# Marks dropped samples (NaN, Inf, log-axis violations) as NAN up front
-	# so the inner draw loop only needs a single is_nan() check per sample.
-	func _build_independent_y_row(p_ctx: _SeriesDrawContext) -> PackedFloat64Array:
-		var sample_count := _dataset.get_series_sample_count(p_ctx.series_id)
-		var y_plotted := PackedFloat64Array()
-		y_plotted.resize(sample_count)
-		y_plotted.fill(NAN)
-		for i in range(sample_count):
-			var y := _dataset.get_series_y(p_ctx.series_id, i)
-			if is_nan(y) or is_inf(y):
-				continue
-			if p_ctx.y_is_log and y <= 0.0:
-				continue
-			y_plotted[i] = y
+	# Marks dropped samples (NaN, Inf, log-axis violations) as NAN before the
+	# draw loop, so that loop only needs one is_nan() check per sample.
+	#
+	# Optimization. The row is read in one call and rewritten in place. Reading
+	# one sample at a time would cost a series lookup and a ring mapping per
+	# value. The log test runs once before the loop instead of once per sample,
+	# and one is_finite() replaces the two calls that checked NaN and Inf.
+	func _build_independent_y_row(p_ctx: _SeriesDrawContext, p_sample_count: int) -> PackedFloat64Array:
+		var y_plotted := _dataset.get_series_y_slice(p_ctx.series_id, 0, p_sample_count)
+		if p_ctx.y_is_log:
+			for i in range(p_sample_count):
+				var y := y_plotted[i]
+				if not is_finite(y) or y <= 0.0:
+					y_plotted[i] = NAN
+		else:
+			for i in range(p_sample_count):
+				if not is_finite(y_plotted[i]):
+					y_plotted[i] = NAN
 		return y_plotted
 
 
@@ -2007,11 +2021,13 @@ class LineRenderer extends Control:
 
 
 	func _resolve_sample_color_only(p_ctx: _SeriesDrawContext, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> Color:
-		# Per-sample override from LineVisualAttributes.color_buffer. The lower
-		# bound is guaranteed by the sample loop. The upper one is real: a
-		# buffer shorter than the series falls through to the resolved style.
+		# Per-sample override from LineVisualAttributes.color_buffer. The sample
+		# loop already keeps the index at 0 or above. The test below is the
+		# upper limit, and it is a real one: a buffer shorter than the series
+		# falls back to the resolved style. Together they make the index valid,
+		# which is what the unsafe read needs.
 		if p_ctx.color_buffer != null and p_sample_index < p_ctx.color_buffer_size:
-			var c := p_ctx.color_buffer.get_value(p_sample_index)
+			var c := p_ctx.color_buffer.get_value_unsafe(p_sample_index)
 			if c != VisualAttributes.ColorBuffer.NO_COLOR:
 				return c
 
@@ -2025,10 +2041,10 @@ class LineRenderer extends Control:
 
 
 	func _resolve_sample_alpha(p_ctx: _SeriesDrawContext, p_sample_index: int, p_x_value: Variant, p_y_value: float) -> float:
-		# Per-sample override from LineVisualAttributes.alpha_buffer, bounded
-		# like the color buffer.
+		# Per-sample override from LineVisualAttributes.alpha_buffer, with the
+		# same index limit as the color buffer.
 		if p_ctx.alpha_buffer != null and p_sample_index < p_ctx.alpha_buffer_size:
-			var a := p_ctx.alpha_buffer.get_value(p_sample_index)
+			var a := p_ctx.alpha_buffer.get_value_unsafe(p_sample_index)
 			if a >= 0.0:
 				return a
 

--- a/addons/tau-plot/plot/xy/xy_layout.gd
+++ b/addons/tau-plot/plot/xy/xy_layout.gd
@@ -19,6 +19,65 @@ class XYLayout extends RefCounted:
 	## Must be set by the caller before calling [method update].
 	var style: TauXYStyle = null
 
+	## Transform from a data value to a pixel along one axis of one pane.
+	##
+	## Optimization. Folds the pane rectangle, the domain bounds, the inversion
+	## and the scale into a single multiply-add, resolved once by
+	## [method update]. Deriving them inside the mapping functions would repeat
+	## all four for every mapped value.
+	class AxisMapping extends RefCounted:
+		# The domain offset, the inversion and the pixel extent all collapse
+		# into this pair. On a logarithmic axis it applies to the logarithm of
+		# the value: the ratio cancels the base, so the raw log() is used.
+		var _scale_px: float = 0.0
+		var _offset_px: float = 0.0
+		var _is_log: bool = false
+
+		# A collapsed domain or a zero-extent pane has no transform. Held as a
+		# flag so the normal path stays a multiply-add.
+		var _degenerate: bool = false
+
+		# Pixel returned when a value has no mapping: every value when the
+		# transform is degenerate, a non-positive value on a logarithmic axis.
+		var _fallback_px: float = 0.0
+
+		## Resolves the transform.
+		## [param p_min] Domain minimum.
+		## [param p_max] Domain maximum.
+		## [param p_is_log] True for a logarithmic scale.
+		## [param p_origin] Pixel of the axis start.
+		## [param p_extent] Pixel length of the axis.
+		## [param p_invert] True when higher values map to lower pixels.
+		## [param p_degenerate_px] Pixel returned when the domain is collapsed
+		##   or the pane has no extent. Explicit because the x and y mappings
+		##   answer differently there.
+		func _init(p_min: float, p_max: float, p_is_log: bool, p_origin: float, p_extent: float, p_invert: bool, p_degenerate_px: float) -> void:
+			_is_log = p_is_log
+			if p_min >= p_max or p_extent <= 0.0:
+				_degenerate = true
+				_fallback_px = p_degenerate_px
+				return
+
+			var start_px: float = p_origin + p_extent if p_invert else p_origin
+			var signed_extent: float = -p_extent if p_invert else p_extent
+			var domain_min: float = log(p_min) if p_is_log else p_min
+			var domain_max: float = log(p_max) if p_is_log else p_max
+			_fallback_px = start_px
+			_scale_px = signed_extent / (domain_max - domain_min)
+			_offset_px = start_px - domain_min * _scale_px
+
+		## Returns the axis pixel of [param p_value].
+		func to_px(p_value: float) -> float:
+			if _degenerate:
+				return _fallback_px
+			if _is_log:
+				if p_value <= 0.0:
+					push_error("AxisMapping.to_px(): a logarithmic axis requires a strictly positive value (value=%f)" % p_value)
+					return _fallback_px
+				return _offset_px + log(p_value) * _scale_px
+			return _offset_px + p_value * _scale_px
+
+
 	## Per-pane layout outputs computed by [method update].
 	class PaneLayout extends RefCounted:
 		## The final data-area rectangle for this pane, in pane-local pixel
@@ -28,6 +87,17 @@ class XYLayout extends RefCounted:
 		## Tick sequences for y axes on this pane, keyed by [enum AxisId].
 		## Only populated for y axes that have both a config and series data.
 		var y_ticks: Dictionary[AxisId, TickSequence] = {}
+
+		## Transform for the primary x axis on this pane.
+		var x_mapping: AxisMapping = null
+
+		## Transform for the secondary x axis on this pane, or null when the
+		## plot has no secondary x axis.
+		var secondary_x_mapping: AxisMapping = null
+
+		## Transforms for the y axes on this pane, keyed by [enum AxisId].
+		## Only populated for y axes that have a domain.
+		var y_mappings: Dictionary[AxisId, AxisMapping] = {}
 
 		## Zero-based index of this pane within the pane list. Input.
 		var pane_index: int = 0
@@ -212,6 +282,8 @@ class XYLayout extends RefCounted:
 
 		_compute_all_pane_rects(draws_bottom, draws_top, draws_left, draws_right, y_axes)
 
+		_compute_axis_mappings(y_axes, has_secondary_x)
+
 
 	## Returns true if [param p_pane_index] is the pane closest to [param p_edge].
 	## In a vertical stack (x horizontal), TOP is nearest pane 0, BOTTOM is nearest pane N-1.
@@ -255,47 +327,25 @@ class XYLayout extends RefCounted:
 	# Axis mapping
 	################################################################################################
 
+	## Returns the transform from an x-axis data value to a pixel along the x axis direction.
+	## [param p_pane_index] Zero-based pane index.
+	func get_x_mapping(p_pane_index: int) -> AxisMapping:
+		return pane_layouts[p_pane_index].x_mapping
+
+
+	## Returns the transform from an y-axis data value to a pixel along the y axis direction.
+	## [param p_pane_index] Zero-based pane index.
+	## [param p_y_axis_id] Which y axis.
+	func get_y_mapping(p_pane_index: int, p_y_axis_id: AxisId) -> AxisMapping:
+		return pane_layouts[p_pane_index].y_mappings[p_y_axis_id]
+
+
 	## Maps an x-axis data value to a pixel coordinate along the x axis direction.
 	## Returns a screen-X pixel when x is horizontal, or screen-Y when x is vertical.
 	## [param p_pane_index] Zero-based pane index.
 	## [param p_x] Data value on the x axis.
 	func map_x_to_px(p_pane_index: int, p_x: float) -> float:
-		if p_pane_index < 0 or p_pane_index >= pane_layouts.size():
-			return 0.0
-		var pane_layout := pane_layouts[p_pane_index]
-		var x_axis_cfg := domain.config.x_axis
-		if x_axis_cfg == null:
-			return pane_layout.pane_rect.position.x
-
-		# x horizontal: origin and extent are along screen-X.
-		# x vertical: origin and extent are along screen-Y.
-		var origin: float = pane_layout.pane_rect.position.x if _x_is_horizontal else pane_layout.pane_rect.position.y
-		var extent: float = pane_layout.pane_rect.size.x if _x_is_horizontal else pane_layout.pane_rect.size.y
-
-		var domain_x_min := domain.x_axis_domain.min_val
-		var domain_x_max := domain.x_axis_domain.max_val
-		if domain_x_min >= domain_x_max or extent <= 0.0:
-			return origin
-
-		# Notes:
-		# - screen-X increases rightward
-		# - screen-Y increases downward
-		# As a consequence, when the x axis is vertical an inversion is required to get x min at
-		# the bottom and x max at the top.
-		# The user-facing "inverted" flag flips the direction on top of the
-		# orientation-based default (XOR logic).
-		var flip: bool = (not _x_is_horizontal) != x_axis_cfg.inverted
-		match x_axis_cfg.scale:
-			TauAxisConfig.Scale.LOGARITHMIC:
-				return _map_log_value_to_px(p_x, domain_x_min, domain_x_max, origin, extent, flip)
-			TauAxisConfig.Scale.LINEAR:
-				var t := (p_x - domain_x_min) / (domain_x_max - domain_x_min)
-				if flip:
-					t = 1.0 - t
-				return origin + t * extent
-			_:
-				push_error("Unexpected scale %d" % x_axis_cfg.scale)
-				return origin
+		return pane_layouts[p_pane_index].x_mapping.to_px(p_x)
 
 
 	## Maps a secondary x-axis data value to a pixel coordinate along the x
@@ -305,30 +355,7 @@ class XYLayout extends RefCounted:
 	## [param p_pane_index] Zero-based pane index.
 	## [param p_x] Data value in the secondary x axis domain.
 	func map_secondary_x_to_px(p_pane_index: int, p_x: float) -> float:
-		if p_pane_index < 0 or p_pane_index >= pane_layouts.size():
-			return 0.0
-		var pane_layout := pane_layouts[p_pane_index]
-		var secondary_cfg := domain.config.secondary_x_axis
-		if secondary_cfg == null:
-			return pane_layout.pane_rect.position.x
-
-		var origin: float = pane_layout.pane_rect.position.x if _x_is_horizontal else pane_layout.pane_rect.position.y
-		var extent: float = pane_layout.pane_rect.size.x if _x_is_horizontal else pane_layout.pane_rect.size.y
-
-		if _secondary_x_domain_min >= _secondary_x_domain_max or extent <= 0.0:
-			return origin
-
-		match secondary_cfg.scale:
-			TauAxisConfig.Scale.LOGARITHMIC:
-				return _map_log_value_to_px(p_x, _secondary_x_domain_min, _secondary_x_domain_max, origin, extent, not _x_is_horizontal)
-			TauAxisConfig.Scale.LINEAR:
-				var t := (p_x - _secondary_x_domain_min) / (_secondary_x_domain_max - _secondary_x_domain_min)
-				if not _x_is_horizontal:
-					t = 1.0 - t
-				return origin + t * extent
-			_:
-				push_error("Unexpected scale %d" % secondary_cfg.scale)
-				return origin
+		return pane_layouts[p_pane_index].secondary_x_mapping.to_px(p_x)
 
 
 	## Maps a categorical x-axis index to the pixel coordinate at the center of
@@ -360,25 +387,7 @@ class XYLayout extends RefCounted:
 	## [param p_value] Data value on the y axis.
 	## [param p_y_axis_id] Which y axis (one of the two orthogonal positions).
 	func map_y_to_px(p_pane_index: int, p_value: float, p_y_axis_id: AxisId) -> float:
-		if p_pane_index < 0 or p_pane_index >= pane_layouts.size():
-			return 0.0
-		var pane_layout := pane_layouts[p_pane_index]
-
-		var y_axis_domain := _get_y_axis_domain(p_pane_index, p_y_axis_id)
-		if y_axis_domain == null:
-			push_error("map_y_to_px(): no y axis domain for axis_id %d" % p_y_axis_id)
-			return 0.0
-
-		# x horizontal: y axis runs along screen-Y. x vertical: y axis runs along screen-X.
-		var origin: float = pane_layout.pane_rect.position.y if _x_is_horizontal else pane_layout.pane_rect.position.x
-		var extent: float = pane_layout.pane_rect.size.y if _x_is_horizontal else pane_layout.pane_rect.size.x
-		# x horizontal: y is vertical, so invert (higher values = lower screen-Y = up).
-		# x vertical: y is horizontal, values increase with screen-X, no inversion.
-		# The user-facing "inverted" flag flips the direction on top of the
-		# orientation-based default (XOR logic).
-		var y_cfg := y_axis_domain.config
-		var flip: bool = _x_is_horizontal != (y_cfg != null and y_cfg.inverted)
-		return _map_y_value(p_value, y_axis_domain.min_val, y_axis_domain.max_val, y_axis_domain.scale, origin, extent, flip)
+		return pane_layouts[p_pane_index].y_mappings[p_y_axis_id].to_px(p_value)
 
 
 	## Returns the pixel coordinate of y=0 on the given y axis.
@@ -475,53 +484,53 @@ class XYLayout extends RefCounted:
 		return y_axis_domain.config
 
 
-	## Maps a y data value to a pixel coordinate using linear or log scale.
-	## [param p_value] Data value.
-	## [param p_min] Domain minimum.
-	## [param p_max] Domain maximum.
-	## [param p_scale] LINEAR or LOGARITHMIC.
-	## [param p_origin] Pixel coordinate of the axis start (top or left of pane rect).
-	## [param p_extent] Pixel length of the axis in screen space.
-	## [param p_invert] If true, higher data values map to lower pixel coordinates
-	##   (used when y is vertical, because screen-Y increases downward).
-	##   If false, higher data values map to higher pixel coordinates
-	##   (used when y is horizontal, because screen-X increases rightward).
-	func _map_y_value(p_value: float, p_min: float, p_max: float, p_scale: TauAxisConfig.Scale, p_origin: float, p_extent: float, p_invert: bool) -> float:
-		if p_min >= p_max or p_extent <= 0.0:
-			return p_origin + p_extent if p_invert else p_origin
-		match p_scale:
-			TauAxisConfig.Scale.LOGARITHMIC:
-				return _map_log_value_to_px(p_value, p_min, p_max, p_origin, p_extent, p_invert)
-			TauAxisConfig.Scale.LINEAR:
-				var t := (p_value - p_min) / (p_max - p_min)
-				if p_invert:
-					return p_origin + (1.0 - t) * p_extent
-				else:
-					return p_origin + t * p_extent
-			_:
-				push_error("Unexpected scale %d" % p_scale)
-				return p_origin + p_extent if p_invert else p_origin
+	## Resolves one [AxisMapping] per axis and per pane from the pane rectangles and the domain bounds.
+	func _compute_axis_mappings(p_y_axes: Array[AxisId], p_has_secondary_x: bool) -> void:
+		var x_axis_cfg := domain.config.x_axis
+		var x_is_log := x_axis_cfg.scale == TauAxisConfig.Scale.LOGARITHMIC
+		# Notes:
+		# - screen-X increases rightward
+		# - screen-Y increases downward
+		# As a consequence, when the x axis is vertical an inversion is required
+		# to get x min at the bottom and x max at the top.
+		# The user-facing "inverted" flag flips the direction on top of the
+		# orientation-based default (XOR logic).
+		var x_flip: bool = (not _x_is_horizontal) != x_axis_cfg.inverted
 
+		for i in range(pane_layouts.size()):
+			var pane_layout := pane_layouts[i]
+			var pane_rect := pane_layout.pane_rect
 
-	## Maps a data value to a pixel coordinate using a base-10 logarithmic scale.
-	## [param p_invert] If true, higher values map to lower pixel coordinates.
-	func _map_log_value_to_px(p_value: float, p_min: float, p_max: float, p_pane_start: float, p_pane_size: float, p_invert: bool) -> float:
-		if p_value <= 0.0 or p_min <= 0.0 or p_max <= 0.0:
-			push_error("Logarithmic mapping requires strictly positive values (value=%f, min=%f, max=%f)" % [p_value, p_min, p_max])
-			return (p_pane_start + p_pane_size) if p_invert else p_pane_start
+			# x horizontal: the x axis runs along screen-X and the y axes along
+			# screen-Y. x vertical: the two are swapped.
+			var x_origin: float = pane_rect.position.x if _x_is_horizontal else pane_rect.position.y
+			var x_extent: float = pane_rect.size.x if _x_is_horizontal else pane_rect.size.y
+			var y_origin: float = pane_rect.position.y if _x_is_horizontal else pane_rect.position.x
+			var y_extent: float = pane_rect.size.y if _x_is_horizontal else pane_rect.size.x
 
-		if p_min >= p_max or p_pane_size <= 0.0:
-			return (p_pane_start + p_pane_size) if p_invert else p_pane_start
+			pane_layout.x_mapping = AxisMapping.new(
+				domain.x_axis_domain.min_val, domain.x_axis_domain.max_val, x_is_log,
+				x_origin, x_extent, x_flip, x_origin)
 
-		const LOG_10 := log(10.0)
-		var log_value := log(p_value) / LOG_10
-		var log_min := log(p_min) / LOG_10
-		var log_max := log(p_max) / LOG_10
-		var t := (log_value - log_min) / (log_max - log_min)
-		if p_invert:
-			return p_pane_start + (1.0 - t) * p_pane_size
-		else:
-			return p_pane_start + t * p_pane_size
+			if p_has_secondary_x:
+				pane_layout.secondary_x_mapping = AxisMapping.new(
+					_secondary_x_domain_min, _secondary_x_domain_max,
+					domain.config.secondary_x_axis.scale == TauAxisConfig.Scale.LOGARITHMIC,
+					x_origin, x_extent, not _x_is_horizontal, x_origin)
+
+			for y_axis_id in p_y_axes:
+				var y_axis_domain := _get_y_axis_domain(i, y_axis_id)
+				if y_axis_domain == null:
+					continue
+				# x horizontal: y is vertical, so invert (higher values = lower
+				# screen-Y = up). x vertical: y is horizontal, values increase
+				# with screen-X, no inversion. Same XOR with "inverted" as x.
+				var y_flip: bool = _x_is_horizontal != y_axis_domain.config.inverted
+				var y_start_px: float = y_origin + y_extent if y_flip else y_origin
+				pane_layout.y_mappings[y_axis_id] = AxisMapping.new(
+					y_axis_domain.min_val, y_axis_domain.max_val,
+					y_axis_domain.scale == TauAxisConfig.Scale.LOGARITHMIC,
+					y_origin, y_extent, y_flip, y_start_px)
 
 
 	## Returns the pixel size (width, height) of a label string using the current style font.

--- a/addons/tau-plot/plot/xy/xy_plot.gd
+++ b/addons/tau-plot/plot/xy/xy_plot.gd
@@ -550,6 +550,10 @@ func refresh(p_plot_global_position: Vector2, p_legend_position: Position) -> vo
 			has_any_bar = true
 			break
 
+	# hoverable lives on the overlay configs, and a renderer caches hit records
+	# only while it is set.
+	var overlay_config_changed := false
+
 	if has_any_bar:
 		for pane_index in range(pane_count):
 			var pane_bar_config: TauBarConfig = _bar_config_per_pane[pane_index]
@@ -557,6 +561,7 @@ func refresh(p_plot_global_position: Vector2, p_legend_position: Position) -> vo
 				continue
 			var prev_bar_config: TauBarConfig = _state.bar_config_per_pane[pane_index]
 			if not pane_bar_config.is_equal_to(prev_bar_config):
+				overlay_config_changed = true
 				if pane_bar_config.has_layout_affecting_change(prev_bar_config):
 					_domain_dirty = true
 					_ticks_dirty = true
@@ -605,6 +610,7 @@ func refresh(p_plot_global_position: Vector2, p_legend_position: Position) -> vo
 				continue
 			var prev_line_config: TauLineConfig = _state.line_config_per_pane[pane_index]
 			if not pane_line_config.is_equal_to(prev_line_config):
+				overlay_config_changed = true
 				if pane_line_config.has_layout_affecting_change(prev_line_config):
 					_domain_dirty = true
 					_ticks_dirty = true
@@ -614,6 +620,9 @@ func refresh(p_plot_global_position: Vector2, p_legend_position: Position) -> vo
 				else:
 					_line_dirty_panes[pane_index] = true
 				_state.save_line_config_for_pane(pane_index, pane_line_config)
+
+	if overlay_config_changed and _hover_controller != null:
+		_hover_controller.refresh_hit_records_enabled()
 
 	# Step 3b: Check if styles changed (programmatic mutations via config.style.*)
 	# XY style: three-layer change detection (theme dirty, ref change, content mutation).

--- a/documentation/docs/api/color_buffer.md
+++ b/documentation/docs/api/color_buffer.md
@@ -32,7 +32,7 @@ colors.append_value(Color.RED)
 
 1. **A new buffer is empty.** Construction allocates the slots and stores no value, so [`size()`](#size) is `0` and every read fails until the first append. [`clear()`](#clear) returns the buffer to that state.
 
-2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value.
+2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value, and [`get_values()`](#get_values) returns an empty array.
 
 3. **[`append_value()`](#append_value) and [`append_values()`](#append_values) always succeed.** They never reject input. When the buffer is full, the oldest value is silently overwritten. The return value indicates how many existing values were overwritten.
 
@@ -74,7 +74,7 @@ Returns the number of values currently stored. Always between `0` and [`get_capa
 
 ---
 
-### Reading and writing individual values
+### Reading and writing values
 
 #### get_value()
 
@@ -89,6 +89,41 @@ Reading an empty buffer, or a logical index below `0` or at or above [`size()`](
 **Parameters**
 
 * `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`.
+
+---
+
+#### get_value_unsafe()
+
+```gdscript
+get_value_unsafe(p_logical_index: int) -> Color
+```
+
+Returns the `Color` at the given logical index, without checking the index. On a valid index it returns the same value as [`get_value()`](#get_value), and it is faster because it skips the check.
+
+This method is unsafe. An index outside `[0, `[`size()`](#size)` - 1]` is undefined behavior. Use [`get_value()`](#get_value) unless the index is already known to be valid, for example a loop counter that stops at [`size()`](#size).
+
+**Parameters**
+
+* `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`. The method does not check it.
+
+---
+
+#### get_values()
+
+```gdscript
+get_values(p_start_index: int, p_count: int) -> PackedColorArray
+```
+
+Returns `p_count` values, starting at logical index `p_start_index`. Index `0` is the oldest value in the buffer, [`size()`](#size)` - 1` is the most recent. The returned array is a copy, so writing to it does not change the buffer.
+
+If `p_count` is `0` or less, the method returns an empty array and pushes no error. If the range goes outside `[0, `[`size()`](#size)`[`, it pushes an error and returns an empty array.
+
+Reading a whole range at once is faster than reading one value at a time. Use it whenever you need more than a few values.
+
+**Parameters**
+
+* `p_start_index: int` Logical index of the first value to read. Must be in the range `[0, `[`size()`](#size)` - 1]`.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`size()`](#size).
 
 ---
 

--- a/documentation/docs/api/dataset.md
+++ b/documentation/docs/api/dataset.md
@@ -504,7 +504,7 @@ Only valid in [`PER_SERIES_X`](#mode) mode.
 
 ---
 
-### Reading and writing individual values
+### Reading and writing values
 
 #### get_shared_x()
 
@@ -514,6 +514,25 @@ get_shared_x(p_logical_sample_index: int) -> Variant
 
 Returns the X value at the given index from the shared X buffer. Index `0` is the oldest sample in the buffer, `count - 1` is the most recent. Returns `null` in
 [`PER_SERIES_X`](#mode) mode. The return type is `String` for [`CATEGORY`](#xelementtype), `float` for [`NUMERIC`](#xelementtype).
+
+---
+
+#### get_shared_x_numeric_slice()
+
+```gdscript
+get_shared_x_numeric_slice(p_start_index: int, p_count: int) -> PackedFloat64Array
+```
+
+Returns `p_count` shared X values, starting at logical sample index `p_start_index`. Index `0` is the oldest sample in the buffer, `count - 1` is the most recent. The returned array is a copy, so writing to it does not change the dataset.
+
+Needs [`SHARED_X`](#mode) mode and a [`NUMERIC`](#xelementtype) X element type. A [`CATEGORY`](#xelementtype) dataset stores strings, so it has no float row to return. In any other case, or when the range goes outside the stored samples, the method logs an error and returns an empty array.
+
+Reading a whole range at once is faster than calling [`get_shared_x()`](#get_shared_x) for each sample, and the result is typed instead of `Variant`.
+
+**Parameters**
+
+* `p_start_index: int` Logical sample index of the first value to read.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`get_shared_sample_count()`](#get_shared_sample_count).
 
 ---
 
@@ -539,6 +558,26 @@ mode or if the ID is unknown. The return type matches the [`XElementType`](#xele
 
 ---
 
+#### get_series_x_numeric_slice()
+
+```gdscript
+get_series_x_numeric_slice(p_series_id: int, p_start_index: int, p_count: int) -> PackedFloat64Array
+```
+
+Returns `p_count` X values of one series, starting at logical sample index `p_start_index`. Index `0` is the oldest sample in the buffer, `count - 1` is the most recent. The returned array is a copy, so writing to it does not change the dataset.
+
+Needs [`PER_SERIES_X`](#mode) mode and a [`NUMERIC`](#xelementtype) X element type. A [`CATEGORY`](#xelementtype) dataset stores strings, so it has no float row to return. In any other case, when the ID is unknown, or when the range goes outside the stored samples, the method logs an error and returns an empty array.
+
+Reading a whole range at once is faster than calling [`get_series_x()`](#get_series_x) for each sample, and the result is typed instead of `Variant`.
+
+**Parameters**
+
+* `p_series_id: int` ID of the series to read.
+* `p_start_index: int` Logical sample index of the first value to read.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`get_series_sample_count()`](#get_series_sample_count).
+
+---
+
 #### set_series_x()
 
 ```gdscript
@@ -559,6 +598,26 @@ get_series_y(p_series_id: int, p_logical_sample_index: int) -> float
 Returns the Y value at the given index for the specified series. Index `0` is the oldest sample in the buffer, `count - 1` is the most recent. Logs an error and returns `0.0` if the ID is unknown.
 
 Reading an empty series, or a logical index below `0` or at or above [`get_series_sample_count()`](#get_series_sample_count), pushes an error and returns `0.0`. A returned `0.0` is therefore not proof that a sample holds that value.
+
+---
+
+#### get_series_y_slice()
+
+```gdscript
+get_series_y_slice(p_series_id: int, p_start_index: int, p_count: int) -> PackedFloat64Array
+```
+
+Returns `p_count` Y values of one series, starting at logical sample index `p_start_index`. Index `0` is the oldest sample in the buffer, `count - 1` is the most recent. The returned array is a copy, so writing to it does not change the dataset.
+
+Logs an error and returns an empty array when the ID is unknown, or when the range goes outside the stored samples. If `p_count` is `0` or less, the method returns an empty array and logs nothing.
+
+Reading a whole range at once is faster than calling [`get_series_y()`](#get_series_y) for each sample. It is the read counterpart of [`set_series_y_slice()`](#set_series_y_slice).
+
+**Parameters**
+
+* `p_series_id: int` ID of the series to read.
+* `p_start_index: int` Logical sample index of the first value to read.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`get_series_sample_count()`](#get_series_sample_count).
 
 ---
 

--- a/documentation/docs/api/float32_buffer.md
+++ b/documentation/docs/api/float32_buffer.md
@@ -30,7 +30,7 @@ alphas.append_value(0.5)
 
 1. **A new buffer is empty.** Construction allocates the slots and stores no value, so [`size()`](#size) is `0` and every read fails until the first append. [`clear()`](#clear) returns the buffer to that state.
 
-2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value.
+2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value, and [`get_values()`](#get_values) returns an empty array.
 
 3. **[`append_value()`](#append_value) and [`append_values()`](#append_values) always succeed.** They never reject input. When the buffer is full, the oldest value is silently overwritten. The return value indicates how many existing values were overwritten.
 
@@ -72,7 +72,7 @@ Returns the number of values currently stored. Always between `0` and [`get_capa
 
 ---
 
-### Reading and writing individual values
+### Reading and writing values
 
 #### get_value()
 
@@ -87,6 +87,41 @@ Reading an empty buffer, or a logical index below `0` or at or above [`size()`](
 **Parameters**
 
 * `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`.
+
+---
+
+#### get_value_unsafe()
+
+```gdscript
+get_value_unsafe(p_logical_index: int) -> float
+```
+
+Returns the `float` at the given logical index, without checking the index. On a valid index it returns the same value as [`get_value()`](#get_value), and it is faster because it skips the check.
+
+This method is unsafe. An index outside `[0, `[`size()`](#size)` - 1]` is undefined behavior. Use [`get_value()`](#get_value) unless the index is already known to be valid, for example a loop counter that stops at [`size()`](#size).
+
+**Parameters**
+
+* `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`. The method does not check it.
+
+---
+
+#### get_values()
+
+```gdscript
+get_values(p_start_index: int, p_count: int) -> PackedFloat32Array
+```
+
+Returns `p_count` values, starting at logical index `p_start_index`. Index `0` is the oldest value in the buffer, [`size()`](#size)` - 1` is the most recent. The returned array is a copy, so writing to it does not change the buffer.
+
+If `p_count` is `0` or less, the method returns an empty array and pushes no error. If the range goes outside `[0, `[`size()`](#size)`[`, it pushes an error and returns an empty array.
+
+Reading a whole range at once is faster than reading one value at a time. Use it whenever you need more than a few values.
+
+**Parameters**
+
+* `p_start_index: int` Logical index of the first value to read. Must be in the range `[0, `[`size()`](#size)` - 1]`.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`size()`](#size).
 
 ---
 

--- a/documentation/docs/api/float64_buffer.md
+++ b/documentation/docs/api/float64_buffer.md
@@ -30,7 +30,7 @@ y_vals.append_value(3.14159265358979)
 
 1. **A new buffer is empty.** Construction allocates the slots and stores no value, so [`size()`](#size) is `0` and every read fails until the first append. [`clear()`](#clear) returns the buffer to that state.
 
-2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value.
+2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value, and [`get_values()`](#get_values) returns an empty array.
 
 3. **[`append_value()`](#append_value) and [`append_values()`](#append_values) always succeed.** They never reject input. When the buffer is full, the oldest value is silently overwritten. The return value indicates how many existing values were overwritten.
 
@@ -72,7 +72,7 @@ Returns the number of values currently stored. Always between `0` and [`get_capa
 
 ---
 
-### Reading and writing individual values
+### Reading and writing values
 
 #### get_value()
 
@@ -87,6 +87,41 @@ Reading an empty buffer, or a logical index below `0` or at or above [`size()`](
 **Parameters**
 
 * `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`.
+
+---
+
+#### get_value_unsafe()
+
+```gdscript
+get_value_unsafe(p_logical_index: int) -> float
+```
+
+Returns the `float` at the given logical index, without checking the index. On a valid index it returns the same value as [`get_value()`](#get_value), and it is faster because it skips the check.
+
+This method is unsafe. An index outside `[0, `[`size()`](#size)` - 1]` is undefined behavior. Use [`get_value()`](#get_value) unless the index is already known to be valid, for example a loop counter that stops at [`size()`](#size).
+
+**Parameters**
+
+* `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`. The method does not check it.
+
+---
+
+#### get_values()
+
+```gdscript
+get_values(p_start_index: int, p_count: int) -> PackedFloat64Array
+```
+
+Returns `p_count` values, starting at logical index `p_start_index`. Index `0` is the oldest value in the buffer, [`size()`](#size)` - 1` is the most recent. The returned array is a copy, so writing to it does not change the buffer.
+
+If `p_count` is `0` or less, the method returns an empty array and pushes no error. If the range goes outside `[0, `[`size()`](#size)`[`, it pushes an error and returns an empty array.
+
+Reading a whole range at once is faster than reading one value at a time. Use it whenever you need more than a few values.
+
+**Parameters**
+
+* `p_start_index: int` Logical index of the first value to read. Must be in the range `[0, `[`size()`](#size)` - 1]`.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`size()`](#size).
 
 ---
 

--- a/documentation/docs/api/int32_buffer.md
+++ b/documentation/docs/api/int32_buffer.md
@@ -30,7 +30,7 @@ shapes.append_value(1)
 
 1. **A new buffer is empty.** Construction allocates the slots and stores no value, so [`size()`](#size) is `0` and every read fails until the first append. [`clear()`](#clear) returns the buffer to that state.
 
-2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value.
+2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value, and [`get_values()`](#get_values) returns an empty array.
 
 3. **[`append_value()`](#append_value) and [`append_values()`](#append_values) always succeed.** They never reject input. When the buffer is full, the oldest value is silently overwritten. The return value indicates how many existing values were overwritten.
 
@@ -72,7 +72,7 @@ Returns the number of values currently stored. Always between `0` and [`get_capa
 
 ---
 
-### Reading and writing individual values
+### Reading and writing values
 
 #### get_value()
 
@@ -87,6 +87,41 @@ Reading an empty buffer, or a logical index below `0` or at or above [`size()`](
 **Parameters**
 
 * `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`.
+
+---
+
+#### get_value_unsafe()
+
+```gdscript
+get_value_unsafe(p_logical_index: int) -> int
+```
+
+Returns the `int` at the given logical index, without checking the index. On a valid index it returns the same value as [`get_value()`](#get_value), and it is faster because it skips the check.
+
+This method is unsafe. An index outside `[0, `[`size()`](#size)` - 1]` is undefined behavior. Use [`get_value()`](#get_value) unless the index is already known to be valid, for example a loop counter that stops at [`size()`](#size).
+
+**Parameters**
+
+* `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`. The method does not check it.
+
+---
+
+#### get_values()
+
+```gdscript
+get_values(p_start_index: int, p_count: int) -> PackedInt32Array
+```
+
+Returns `p_count` values, starting at logical index `p_start_index`. Index `0` is the oldest value in the buffer, [`size()`](#size)` - 1` is the most recent. The returned array is a copy, so writing to it does not change the buffer.
+
+If `p_count` is `0` or less, the method returns an empty array and pushes no error. If the range goes outside `[0, `[`size()`](#size)`[`, it pushes an error and returns an empty array.
+
+Reading a whole range at once is faster than reading one value at a time. Use it whenever you need more than a few values.
+
+**Parameters**
+
+* `p_start_index: int` Logical index of the first value to read. Must be in the range `[0, `[`size()`](#size)` - 1]`.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`size()`](#size).
 
 ---
 

--- a/documentation/docs/api/string_buffer.md
+++ b/documentation/docs/api/string_buffer.md
@@ -30,7 +30,7 @@ labels.append_value("January")
 
 1. **A new buffer is empty.** Construction allocates the slots and stores no value, so [`size()`](#size) is `0` and every read fails until the first append. [`clear()`](#clear) returns the buffer to that state.
 
-2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value.
+2. **Out-of-range access logs an error.** [`set_value()`](#set_value) and [`set_values()`](#set_values) log an error and write nothing when the buffer is empty or the index is out of range. [`get_value()`](#get_value) reports the same failure through its return value, and [`get_values()`](#get_values) returns an empty array.
 
 3. **[`append_value()`](#append_value) and [`append_values()`](#append_values) always succeed.** They never reject input. When the buffer is full, the oldest value is silently overwritten. The return value indicates how many existing values were overwritten.
 
@@ -72,7 +72,7 @@ Returns the number of values currently stored. Always between `0` and [`get_capa
 
 ---
 
-### Reading and writing individual values
+### Reading and writing values
 
 #### get_value()
 
@@ -87,6 +87,41 @@ Reading an empty buffer, or a logical index below `0` or at or above [`size()`](
 **Parameters**
 
 * `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`.
+
+---
+
+#### get_value_unsafe()
+
+```gdscript
+get_value_unsafe(p_logical_index: int) -> String
+```
+
+Returns the `String` at the given logical index, without checking the index. On a valid index it returns the same value as [`get_value()`](#get_value), and it is faster because it skips the check.
+
+This method is unsafe. An index outside `[0, `[`size()`](#size)` - 1]` is undefined behavior. Use [`get_value()`](#get_value) unless the index is already known to be valid, for example a loop counter that stops at [`size()`](#size).
+
+**Parameters**
+
+* `p_logical_index: int` Logical index in the range `[0, `[`size()`](#size)` - 1]`. The method does not check it.
+
+---
+
+#### get_values()
+
+```gdscript
+get_values(p_start_index: int, p_count: int) -> PackedStringArray
+```
+
+Returns `p_count` values, starting at logical index `p_start_index`. Index `0` is the oldest value in the buffer, [`size()`](#size)` - 1` is the most recent. The returned array is a copy, so writing to it does not change the buffer.
+
+If `p_count` is `0` or less, the method returns an empty array and pushes no error. If the range goes outside `[0, `[`size()`](#size)`[`, it pushes an error and returns an empty array.
+
+Reading a whole range at once is faster than reading one value at a time. Use it whenever you need more than a few values.
+
+**Parameters**
+
+* `p_start_index: int` Logical index of the first value to read. Must be in the range `[0, `[`size()`](#size)` - 1]`.
+* `p_count: int` How many values to read. `p_start_index + p_count` must not be greater than [`size()`](#size).
 
 ---
 


### PR DESCRIPTION
## Description

Demo 2 (Patient Monitor) draws two line series of 1250 samples across two panes and rewrites a few Y values per frame from `_process`. It is 2500 samples redrawn every frame, currently it runs at 18-20 FPS.

A few ideas:
- [x] Stop building hit records when nothing reads them. Done => 23-25 FPS.
- [x] Resolve per-series constants once per draw. Done => 33-35 FPS.
- [x] Optimize ring buffers, support bulk reads. Done => 42-44 FPS.
- [x] Resolve the axis mapping once per series. Done => 71-75 FPS.

## Testing

Demo_2 + non regression tests.


## AI disclosure

Analysis, optimization ideas and implementation drafts made by AI.